### PR TITLE
Add additional CLI options

### DIFF
--- a/packages/cli/dist/declarations/src/commands/init.d.ts
+++ b/packages/cli/dist/declarations/src/commands/init.d.ts
@@ -2,6 +2,7 @@ import { ArgumentsCamelCase } from "yargs";
 export declare type CliArguments = ArgumentsCamelCase<{
     port?: number;
     typescript?: "true" | "false" | boolean;
+    emails_dir?: "./emails" | "./src/emails";
 }>;
 export declare const command: string[];
 export declare const describe = "initialize mailing in your app";

--- a/packages/cli/dist/declarations/src/commands/init.d.ts
+++ b/packages/cli/dist/declarations/src/commands/init.d.ts
@@ -1,6 +1,8 @@
 import { ArgumentsCamelCase } from "yargs";
+export declare type CliArguments = ArgumentsCamelCase<{
+    port?: number;
+    typescript?: "true" | "false" | boolean;
+}>;
 export declare const command: string[];
 export declare const describe = "initialize mailing in your app";
-export declare const handler: (args: ArgumentsCamelCase<{
-    port?: number;
-}>) => Promise<void>;
+export declare const handler: (args: CliArguments) => Promise<void>;

--- a/packages/cli/dist/declarations/src/commands/init.d.ts
+++ b/packages/cli/dist/declarations/src/commands/init.d.ts
@@ -6,4 +6,12 @@ export declare type CliArguments = ArgumentsCamelCase<{
 }>;
 export declare const command: string[];
 export declare const describe = "initialize mailing in your app";
+export declare const builder: {
+    typescript: {
+        description: string;
+    };
+    "emails-dir": {
+        description: string;
+    };
+};
 export declare const handler: (args: CliArguments) => Promise<void>;

--- a/packages/cli/dist/declarations/src/commands/init.d.ts
+++ b/packages/cli/dist/declarations/src/commands/init.d.ts
@@ -2,7 +2,7 @@ import { ArgumentsCamelCase } from "yargs";
 export declare type CliArguments = ArgumentsCamelCase<{
     port?: number;
     typescript?: "true" | "false" | boolean;
-    emails_dir?: "./emails" | "./src/emails";
+    "emails-dir"?: "./emails" | "./src/emails";
 }>;
 export declare const command: string[];
 export declare const describe = "initialize mailing in your app";

--- a/packages/cli/dist/declarations/src/generators.d.ts
+++ b/packages/cli/dist/declarations/src/generators.d.ts
@@ -1,3 +1,4 @@
-export declare function generateEmailsDirectory({ isTypescript, }: {
+export declare function generateEmailsDirectory({ isTypescript, emailsDir, }: {
     isTypescript: boolean;
+    emailsDir?: "./emails" | "./src/emails";
 }): Promise<boolean>;

--- a/packages/cli/dist/mailing.cjs.dev.js
+++ b/packages/cli/dist/mailing.cjs.dev.js
@@ -1122,12 +1122,12 @@ function generateEmailsDirectory(_x) {
 
 function _generateEmailsDirectory() {
   _generateEmailsDirectory = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime().mark(function _callee(_ref) {
-    var isTypescript, existingEmailsPath, emailsPath, response, path$1;
+    var isTypescript, emailsDir, existingEmailsPath, targetEmailsDir, emailsPath, response, path$1;
     return _regeneratorRuntime().wrap(function _callee$(_context) {
       while (1) {
         switch (_context.prev = _context.next) {
           case 0:
-            isTypescript = _ref.isTypescript;
+            isTypescript = _ref.isTypescript, emailsDir = _ref.emailsDir;
             existingEmailsPath = getExistingEmailsDir();
 
             if (!existingEmailsPath) {
@@ -1140,8 +1140,18 @@ function _generateEmailsDirectory() {
             return _context.abrupt("return", false);
 
           case 5:
+            if (!emailsDir) {
+              _context.next = 9;
+              break;
+            }
+
+            targetEmailsDir = emailsDir;
+            _context.next = 14;
+            break;
+
+          case 9:
             emailsPath = getPotentialEmailsDirPath();
-            _context.next = 8;
+            _context.next = 12;
             return prompts__default["default"]({
               type: "text",
               name: "path",
@@ -1149,30 +1159,32 @@ function _generateEmailsDirectory() {
               initial: "./" + path.relative(process.cwd(), emailsPath) + "/"
             });
 
-          case 8:
+          case 12:
             response = _context.sent;
+            targetEmailsDir = response.path;
 
-            if (!response.path) {
-              _context.next = 17;
+          case 14:
+            if (!targetEmailsDir) {
+              _context.next = 22;
               break;
             }
 
             // copy the emails dir template in!
             path$1 = "generator_templates/".concat(isTypescript ? "ts" : "js", "/emails");
-            _context.next = 13;
-            return fsExtra.copySync(path.resolve(__dirname, path$1), response.path, {
+            _context.next = 18;
+            return fsExtra.copySync(path.resolve(__dirname, path$1), targetEmailsDir, {
               overwrite: false
             });
 
-          case 13:
-            log("Generated your emails dir at ".concat(response.path, ":\n").concat(tree__default["default"](response.path)));
+          case 18:
+            log("Generated your emails dir at ".concat(targetEmailsDir, ":\n").concat(tree__default["default"](targetEmailsDir)));
             return _context.abrupt("return", true);
 
-          case 17:
+          case 22:
             log("OK, bye!");
             return _context.abrupt("return", false);
 
-          case 19:
+          case 24:
           case "end":
             return _context.stop();
         }
@@ -1252,7 +1264,8 @@ var handler = /*#__PURE__*/function () {
 
           case 17:
             options = {
-              isTypescript: isTypescript
+              isTypescript: isTypescript,
+              emailsDir: args.emails_dir
             };
             _context.next = 20;
             return generateEmailsDirectory(options);

--- a/packages/cli/dist/mailing.cjs.dev.js
+++ b/packages/cli/dist/mailing.cjs.dev.js
@@ -1214,43 +1214,41 @@ var handler = /*#__PURE__*/function () {
       while (1) {
         switch (_context.prev = _context.next) {
           case 0:
-            console.log(args); // check if emails directory already exists
-
             if (fsExtra.existsSync("./package.json")) {
-              _context.next = 4;
+              _context.next = 3;
               break;
             }
 
             log("No package.json found. Please run from the project root.");
             return _context.abrupt("return");
 
-          case 4:
+          case 3:
             if (getExistingEmailsDir()) {
-              _context.next = 20;
+              _context.next = 19;
               break;
             }
 
             if (!("false" === args.typescript)) {
-              _context.next = 9;
+              _context.next = 8;
               break;
             }
 
             isTypescript = false;
-            _context.next = 17;
+            _context.next = 16;
             break;
 
-          case 9:
+          case 8:
             if (!args.typescript) {
-              _context.next = 13;
+              _context.next = 12;
               break;
             }
 
             isTypescript = true;
-            _context.next = 17;
+            _context.next = 16;
             break;
 
-          case 13:
-            _context.next = 15;
+          case 12:
+            _context.next = 14;
             return prompts__default["default"]({
               type: "confirm",
               name: "value",
@@ -1258,22 +1256,22 @@ var handler = /*#__PURE__*/function () {
               initial: looksLikeTypescriptProject()
             });
 
-          case 15:
+          case 14:
             ts = _context.sent;
             isTypescript = ts.value;
 
-          case 17:
+          case 16:
             options = {
               isTypescript: isTypescript,
-              emailsDir: args.emails_dir
+              emailsDir: args["emails-dir"]
             };
-            _context.next = 20;
+            _context.next = 19;
             return generateEmailsDirectory(options);
 
-          case 20:
+          case 19:
             handler$1(args);
 
-          case 21:
+          case 20:
           case "end":
             return _context.stop();
         }

--- a/packages/cli/dist/mailing.cjs.dev.js
+++ b/packages/cli/dist/mailing.cjs.dev.js
@@ -828,7 +828,7 @@ function _sendPreview() {
 var DEFAULT_PORT = 3883;
 var command$1 = "preview";
 var describe$1 = "start the email preview server";
-var builder = {
+var builder$1 = {
   port: {
     "default": DEFAULT_PORT
   }
@@ -1104,7 +1104,7 @@ var preview = /*#__PURE__*/Object.freeze({
   __proto__: null,
   command: command$1,
   describe: describe$1,
-  builder: builder,
+  builder: builder$1,
   handler: handler$1
 });
 
@@ -1207,6 +1207,14 @@ function looksLikeTypescriptProject() {
 
 var command = ["$0", "init"];
 var describe = "initialize mailing in your app";
+var builder = {
+  typescript: {
+    description: "use Typescript"
+  },
+  "emails-dir": {
+    description: "where to put your emails - ./emails or ./src/emails are currently the only valid options"
+  }
+};
 var handler = /*#__PURE__*/function () {
   var _ref = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime().mark(function _callee(args) {
     var isTypescript, ts, options;
@@ -1288,6 +1296,7 @@ var init = /*#__PURE__*/Object.freeze({
   __proto__: null,
   command: command,
   describe: describe,
+  builder: builder,
   handler: handler
 });
 

--- a/packages/cli/dist/mailing.cjs.dev.js
+++ b/packages/cli/dist/mailing.cjs.dev.js
@@ -643,11 +643,17 @@ function showPreview(req, res) {
 
   var modulePath = path.resolve(previewsPath, moduleName);
   var functionName = functionNameJSON.replace(".json", "");
-  delete require.cache[modulePath];
+  var emailsPath = path.resolve(previewsPath, "..");
 
-  var module = require(modulePath);
+  for (var path$1 in require.cache) {
+    if (path$1.startsWith(emailsPath)) {
+      delete require.cache[path$1];
+    }
+  }
 
-  var component = module[functionName]();
+  var previewModule = require(modulePath);
+
+  var component = previewModule[functionName]();
 
   if (component !== null && component !== void 0 && component.props) {
     try {
@@ -671,7 +677,6 @@ function showPreview(req, res) {
       res.end(JSON.stringify(e));
     }
   } else {
-    var emailsPath = path.resolve(previewsPath, "..");
     var msg = "".concat(functionName, "() from ").concat(modulePath, " must return a react component defined in ").concat(emailsPath);
     error(msg);
     res.writeHead(404);
@@ -1048,10 +1053,6 @@ var handler$1 = /*#__PURE__*/function () {
                       return open__default["default"](currentUrl);
 
                     case 4:
-                      _context2.next = 6;
-                      return open__default["default"](currentUrl);
-
-                    case 6:
                     case "end":
                       return _context2.stop();
                   }
@@ -1196,26 +1197,48 @@ var command = ["$0", "init"];
 var describe = "initialize mailing in your app";
 var handler = /*#__PURE__*/function () {
   var _ref = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime().mark(function _callee(args) {
-    var ts, options;
+    var isTypescript, ts, options;
     return _regeneratorRuntime().wrap(function _callee$(_context) {
       while (1) {
         switch (_context.prev = _context.next) {
           case 0:
+            console.log(args); // check if emails directory already exists
+
             if (fsExtra.existsSync("./package.json")) {
-              _context.next = 3;
+              _context.next = 4;
               break;
             }
 
             log("No package.json found. Please run from the project root.");
             return _context.abrupt("return");
 
-          case 3:
+          case 4:
             if (getExistingEmailsDir()) {
-              _context.next = 10;
+              _context.next = 20;
               break;
             }
 
-            _context.next = 6;
+            if (!("false" === args.typescript)) {
+              _context.next = 9;
+              break;
+            }
+
+            isTypescript = false;
+            _context.next = 17;
+            break;
+
+          case 9:
+            if (!args.typescript) {
+              _context.next = 13;
+              break;
+            }
+
+            isTypescript = true;
+            _context.next = 17;
+            break;
+
+          case 13:
+            _context.next = 15;
             return prompts__default["default"]({
               type: "confirm",
               name: "value",
@@ -1223,18 +1246,21 @@ var handler = /*#__PURE__*/function () {
               initial: looksLikeTypescriptProject()
             });
 
-          case 6:
+          case 15:
             ts = _context.sent;
+            isTypescript = ts.value;
+
+          case 17:
             options = {
-              isTypescript: ts.value
+              isTypescript: isTypescript
             };
-            _context.next = 10;
+            _context.next = 20;
             return generateEmailsDirectory(options);
 
-          case 10:
+          case 20:
             handler$1(args);
 
-          case 11:
+          case 21:
           case "end":
             return _context.stop();
         }

--- a/packages/cli/dist/mailing.cjs.prod.js
+++ b/packages/cli/dist/mailing.cjs.prod.js
@@ -1212,43 +1212,41 @@ var handler = /*#__PURE__*/function () {
       while (1) {
         switch (_context.prev = _context.next) {
           case 0:
-            console.log(args); // check if emails directory already exists
-
             if (fsExtra.existsSync("./package.json")) {
-              _context.next = 4;
+              _context.next = 3;
               break;
             }
 
             log("No package.json found. Please run from the project root.");
             return _context.abrupt("return");
 
-          case 4:
+          case 3:
             if (getExistingEmailsDir()) {
-              _context.next = 20;
+              _context.next = 19;
               break;
             }
 
             if (!("false" === args.typescript)) {
-              _context.next = 9;
+              _context.next = 8;
               break;
             }
 
             isTypescript = false;
-            _context.next = 17;
+            _context.next = 16;
             break;
 
-          case 9:
+          case 8:
             if (!args.typescript) {
-              _context.next = 13;
+              _context.next = 12;
               break;
             }
 
             isTypescript = true;
-            _context.next = 17;
+            _context.next = 16;
             break;
 
-          case 13:
-            _context.next = 15;
+          case 12:
+            _context.next = 14;
             return prompts__default["default"]({
               type: "confirm",
               name: "value",
@@ -1256,22 +1254,22 @@ var handler = /*#__PURE__*/function () {
               initial: looksLikeTypescriptProject()
             });
 
-          case 15:
+          case 14:
             ts = _context.sent;
             isTypescript = ts.value;
 
-          case 17:
+          case 16:
             options = {
               isTypescript: isTypescript,
-              emailsDir: args.emails_dir
+              emailsDir: args["emails-dir"]
             };
-            _context.next = 20;
+            _context.next = 19;
             return generateEmailsDirectory(options);
 
-          case 20:
+          case 19:
             handler$1(args);
 
-          case 21:
+          case 20:
           case "end":
             return _context.stop();
         }

--- a/packages/cli/dist/mailing.cjs.prod.js
+++ b/packages/cli/dist/mailing.cjs.prod.js
@@ -643,11 +643,17 @@ function showPreview(req, res) {
 
   var modulePath = path.resolve(previewsPath, moduleName);
   var functionName = functionNameJSON.replace(".json", "");
-  delete require.cache[modulePath];
+  var emailsPath = path.resolve(previewsPath, "..");
 
-  var module = require(modulePath);
+  for (var path$1 in require.cache) {
+    if (path$1.startsWith(emailsPath)) {
+      delete require.cache[path$1];
+    }
+  }
 
-  var component = module[functionName]();
+  var previewModule = require(modulePath);
+
+  var component = previewModule[functionName]();
 
   if (component !== null && component !== void 0 && component.props) {
     try {
@@ -671,7 +677,6 @@ function showPreview(req, res) {
       res.end(JSON.stringify(e));
     }
   } else {
-    var emailsPath = path.resolve(previewsPath, "..");
     var msg = "".concat(functionName, "() from ").concat(modulePath, " must return a react component defined in ").concat(emailsPath);
     error(msg);
     res.writeHead(404);
@@ -1046,10 +1051,6 @@ var handler$1 = /*#__PURE__*/function () {
                       return open__default["default"](currentUrl);
 
                     case 4:
-                      _context2.next = 6;
-                      return open__default["default"](currentUrl);
-
-                    case 6:
                     case "end":
                       return _context2.stop();
                   }
@@ -1194,26 +1195,48 @@ var command = ["$0", "init"];
 var describe = "initialize mailing in your app";
 var handler = /*#__PURE__*/function () {
   var _ref = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime().mark(function _callee(args) {
-    var ts, options;
+    var isTypescript, ts, options;
     return _regeneratorRuntime().wrap(function _callee$(_context) {
       while (1) {
         switch (_context.prev = _context.next) {
           case 0:
+            console.log(args); // check if emails directory already exists
+
             if (fsExtra.existsSync("./package.json")) {
-              _context.next = 3;
+              _context.next = 4;
               break;
             }
 
             log("No package.json found. Please run from the project root.");
             return _context.abrupt("return");
 
-          case 3:
+          case 4:
             if (getExistingEmailsDir()) {
-              _context.next = 10;
+              _context.next = 20;
               break;
             }
 
-            _context.next = 6;
+            if (!("false" === args.typescript)) {
+              _context.next = 9;
+              break;
+            }
+
+            isTypescript = false;
+            _context.next = 17;
+            break;
+
+          case 9:
+            if (!args.typescript) {
+              _context.next = 13;
+              break;
+            }
+
+            isTypescript = true;
+            _context.next = 17;
+            break;
+
+          case 13:
+            _context.next = 15;
             return prompts__default["default"]({
               type: "confirm",
               name: "value",
@@ -1221,18 +1244,21 @@ var handler = /*#__PURE__*/function () {
               initial: looksLikeTypescriptProject()
             });
 
-          case 6:
+          case 15:
             ts = _context.sent;
+            isTypescript = ts.value;
+
+          case 17:
             options = {
-              isTypescript: ts.value
+              isTypescript: isTypescript
             };
-            _context.next = 10;
+            _context.next = 20;
             return generateEmailsDirectory(options);
 
-          case 10:
+          case 20:
             handler$1(args);
 
-          case 11:
+          case 21:
           case "end":
             return _context.stop();
         }

--- a/packages/cli/dist/mailing.cjs.prod.js
+++ b/packages/cli/dist/mailing.cjs.prod.js
@@ -1120,12 +1120,12 @@ function generateEmailsDirectory(_x) {
 
 function _generateEmailsDirectory() {
   _generateEmailsDirectory = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime().mark(function _callee(_ref) {
-    var isTypescript, existingEmailsPath, emailsPath, response, path$1;
+    var isTypescript, emailsDir, existingEmailsPath, targetEmailsDir, emailsPath, response, path$1;
     return _regeneratorRuntime().wrap(function _callee$(_context) {
       while (1) {
         switch (_context.prev = _context.next) {
           case 0:
-            isTypescript = _ref.isTypescript;
+            isTypescript = _ref.isTypescript, emailsDir = _ref.emailsDir;
             existingEmailsPath = getExistingEmailsDir();
 
             if (!existingEmailsPath) {
@@ -1138,8 +1138,18 @@ function _generateEmailsDirectory() {
             return _context.abrupt("return", false);
 
           case 5:
+            if (!emailsDir) {
+              _context.next = 9;
+              break;
+            }
+
+            targetEmailsDir = emailsDir;
+            _context.next = 14;
+            break;
+
+          case 9:
             emailsPath = getPotentialEmailsDirPath();
-            _context.next = 8;
+            _context.next = 12;
             return prompts__default["default"]({
               type: "text",
               name: "path",
@@ -1147,30 +1157,32 @@ function _generateEmailsDirectory() {
               initial: "./" + path.relative(process.cwd(), emailsPath) + "/"
             });
 
-          case 8:
+          case 12:
             response = _context.sent;
+            targetEmailsDir = response.path;
 
-            if (!response.path) {
-              _context.next = 17;
+          case 14:
+            if (!targetEmailsDir) {
+              _context.next = 22;
               break;
             }
 
             // copy the emails dir template in!
             path$1 = "generator_templates/".concat(isTypescript ? "ts" : "js", "/emails");
-            _context.next = 13;
-            return fsExtra.copySync(path.resolve(__dirname, path$1), response.path, {
+            _context.next = 18;
+            return fsExtra.copySync(path.resolve(__dirname, path$1), targetEmailsDir, {
               overwrite: false
             });
 
-          case 13:
-            log("Generated your emails dir at ".concat(response.path, ":\n").concat(tree__default["default"](response.path)));
+          case 18:
+            log("Generated your emails dir at ".concat(targetEmailsDir, ":\n").concat(tree__default["default"](targetEmailsDir)));
             return _context.abrupt("return", true);
 
-          case 17:
+          case 22:
             log("OK, bye!");
             return _context.abrupt("return", false);
 
-          case 19:
+          case 24:
           case "end":
             return _context.stop();
         }
@@ -1250,7 +1262,8 @@ var handler = /*#__PURE__*/function () {
 
           case 17:
             options = {
-              isTypescript: isTypescript
+              isTypescript: isTypescript,
+              emailsDir: args.emails_dir
             };
             _context.next = 20;
             return generateEmailsDirectory(options);

--- a/packages/cli/dist/mailing.cjs.prod.js
+++ b/packages/cli/dist/mailing.cjs.prod.js
@@ -828,7 +828,7 @@ function _sendPreview() {
 var DEFAULT_PORT = 3883;
 var command$1 = "preview";
 var describe$1 = "start the email preview server";
-var builder = {
+var builder$1 = {
   port: {
     "default": DEFAULT_PORT
   }
@@ -1102,7 +1102,7 @@ var preview = /*#__PURE__*/Object.freeze({
   __proto__: null,
   command: command$1,
   describe: describe$1,
-  builder: builder,
+  builder: builder$1,
   handler: handler$1
 });
 
@@ -1205,6 +1205,14 @@ function looksLikeTypescriptProject() {
 
 var command = ["$0", "init"];
 var describe = "initialize mailing in your app";
+var builder = {
+  typescript: {
+    description: "use Typescript"
+  },
+  "emails-dir": {
+    description: "where to put your emails - ./emails or ./src/emails are currently the only valid options"
+  }
+};
 var handler = /*#__PURE__*/function () {
   var _ref = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime().mark(function _callee(args) {
     var isTypescript, ts, options;
@@ -1286,6 +1294,7 @@ var init = /*#__PURE__*/Object.freeze({
   __proto__: null,
   command: command,
   describe: describe,
+  builder: builder,
   handler: handler
 });
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -26,7 +26,6 @@ export const command = ["$0", "init"];
 export const describe = "initialize mailing in your app";
 
 export const handler = async (args: CliArguments) => {
-  console.log(args);
   // check if emails directory already exists
   if (!existsSync("./package.json")) {
     log("No package.json found. Please run from the project root.");

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -9,7 +9,7 @@ import { handler as previewHandler } from "./preview";
 export type CliArguments = ArgumentsCamelCase<{
   port?: number;
   typescript?: "true" | "false" | boolean;
-  emails_dir?: "./emails" | "./src/emails";
+  "emails-dir"?: "./emails" | "./src/emails";
 }>;
 
 function looksLikeTypescriptProject(): boolean {
@@ -49,7 +49,10 @@ export const handler = async (args: CliArguments) => {
       isTypescript = ts.value;
     }
 
-    const options = { isTypescript: isTypescript, emailsDir: args.emails_dir };
+    const options = {
+      isTypescript: isTypescript,
+      emailsDir: args["emails-dir"],
+    };
     await generateEmailsDirectory(options);
   }
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -6,6 +6,11 @@ import { getExistingEmailsDir, getPackageJSON } from "../paths";
 import { generateEmailsDirectory } from "../generators";
 import { handler as previewHandler } from "./preview";
 
+export type CliArguments = ArgumentsCamelCase<{
+  port?: number;
+  typescript?: "true" | "false" | boolean;
+}>;
+
 function looksLikeTypescriptProject() {
   if (existsSync("./tsconfig.json")) {
     return true;
@@ -19,7 +24,8 @@ export const command = ["$0", "init"];
 
 export const describe = "initialize mailing in your app";
 
-export const handler = async (args: ArgumentsCamelCase<{ port?: number }>) => {
+export const handler = async (args: CliArguments) => {
+  console.log(args);
   // check if emails directory already exists
   if (!existsSync("./package.json")) {
     log("No package.json found. Please run from the project root.");
@@ -27,14 +33,23 @@ export const handler = async (args: ArgumentsCamelCase<{ port?: number }>) => {
   }
 
   if (!getExistingEmailsDir()) {
-    const ts = await prompts({
-      type: "confirm",
-      name: "value",
-      message: "Are you using typescript?",
-      initial: looksLikeTypescriptProject(),
-    });
+    let isTypescript;
 
-    const options = { isTypescript: ts.value };
+    if ("false" === args.typescript) {
+      isTypescript = false;
+    } else if (args.typescript) {
+      isTypescript = true;
+    } else {
+      const ts = await prompts({
+        type: "confirm",
+        name: "value",
+        message: "Are you using typescript?",
+        initial: looksLikeTypescriptProject(),
+      });
+      isTypescript = ts.value;
+    }
+
+    const options = { isTypescript: isTypescript };
     await generateEmailsDirectory(options);
   }
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -25,6 +25,16 @@ export const command = ["$0", "init"];
 
 export const describe = "initialize mailing in your app";
 
+export const builder = {
+  typescript: {
+    description: "use Typescript",
+  },
+  "emails-dir": {
+    description:
+      "where to put your emails - ./emails or ./src/emails are currently the only valid options",
+  },
+};
+
 export const handler = async (args: CliArguments) => {
   // check if emails directory already exists
   if (!existsSync("./package.json")) {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -9,9 +9,10 @@ import { handler as previewHandler } from "./preview";
 export type CliArguments = ArgumentsCamelCase<{
   port?: number;
   typescript?: "true" | "false" | boolean;
+  emails_dir?: "./emails" | "./src/emails";
 }>;
 
-function looksLikeTypescriptProject() {
+function looksLikeTypescriptProject(): boolean {
   if (existsSync("./tsconfig.json")) {
     return true;
   }
@@ -33,8 +34,8 @@ export const handler = async (args: CliArguments) => {
   }
 
   if (!getExistingEmailsDir()) {
+    // options: assign isTypescript
     let isTypescript;
-
     if ("false" === args.typescript) {
       isTypescript = false;
     } else if (args.typescript) {
@@ -49,7 +50,7 @@ export const handler = async (args: CliArguments) => {
       isTypescript = ts.value;
     }
 
-    const options = { isTypescript: isTypescript };
+    const options = { isTypescript: isTypescript, emailsDir: args.emails_dir };
     await generateEmailsDirectory(options);
   }
 

--- a/packages/cli/src/commands/preview.ts
+++ b/packages/cli/src/commands/preview.ts
@@ -157,7 +157,6 @@ export const handler = async (argv: PreviewArgs) => {
     .listen(port, async () => {
       log(`Running preview at ${currentUrl}`);
       if (!argv.quiet) await open(currentUrl);
-      await open(currentUrl);
     })
     .on("error", function onServerError(e: NodeJS.ErrnoException) {
       if (e.code === "EADDRINUSE") {

--- a/packages/cli/src/generators.ts
+++ b/packages/cli/src/generators.ts
@@ -15,8 +15,10 @@ function getPotentialEmailsDirPath() {
 
 export async function generateEmailsDirectory({
   isTypescript,
+  emailsDir,
 }: {
   isTypescript: boolean;
+  emailsDir?: "./emails" | "./src/emails";
 }): Promise<boolean> {
   const existingEmailsPath = getExistingEmailsDir();
   if (existingEmailsPath) {
@@ -25,21 +27,31 @@ export async function generateEmailsDirectory({
     return false;
   }
 
-  const emailsPath = getPotentialEmailsDirPath();
-  const response = await prompts({
-    type: "text",
-    name: "path",
-    message: "Where should we put your emails?",
-    initial: "./" + relative(process.cwd(), emailsPath) + "/",
-  });
-  if (response.path) {
+  let targetEmailsDir;
+
+  if (emailsDir) {
+    targetEmailsDir = emailsDir;
+  } else {
+    const emailsPath = getPotentialEmailsDirPath();
+    const response = await prompts({
+      type: "text",
+      name: "path",
+      message: "Where should we put your emails?",
+      initial: "./" + relative(process.cwd(), emailsPath) + "/",
+    });
+    targetEmailsDir = response.path;
+  }
+
+  if (targetEmailsDir) {
     // copy the emails dir template in!
     const path = `generator_templates/${isTypescript ? "ts" : "js"}/emails`;
-    await copySync(resolve(__dirname, path), response.path, {
+    await copySync(resolve(__dirname, path), targetEmailsDir, {
       overwrite: false,
     });
     log(
-      `Generated your emails dir at ${response.path}:\n${tree(response.path)}`
+      `Generated your emails dir at ${targetEmailsDir}:\n${tree(
+        targetEmailsDir
+      )}`
     );
 
     return true;


### PR DESCRIPTION
In this PR:
- Add 2 options you can specify in CLI: `typescript` and `emails_dir`
- Fix for: `quiet` command always opens browser

@psugihara do you know how to setup the mailing bin --help so it describes the 2 new options?

pre-req for #4

