### PR TITLE
add dotenv for .env file support

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -47,6 +47,7 @@
     "@babel/preset-react": "^7.18.6",
     "@babel/register": "^7.18.9",
     "chalk": "^4.1.2",
+    "dotenv": "^16.0.1",
     "fs-extra": "^10.1.0",
     "mjml": "^4.12.0",
     "mjml-react": "^2.0.7",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,9 @@
+import "dotenv/config";
 import yargs from "yargs/yargs";
 import * as preview from "./commands/preview";
 import * as init from "./commands/init";
 
-yargs(process.argv.slice(2)).command(preview).command(init).help().argv;
+yargs(process.argv.slice(2))
+  .command(preview)
+  .command(init)
+  .help().argv;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4494,6 +4494,11 @@ domutils@^2.0.0, domutils@^2.5.2, domutils@^2.8.0:
     domelementtype "^2.2.0"
     domhandler "^4.2.0"
 
+dotenv@^16.0.1:
+  version "16.0.1"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.1.tgz#8f8f9d94876c35dac989876a5d3a82a267fdce1d"
+  integrity sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==
+
 duplexer2@~0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.1.4.tgz#8b12dab878c0d69e3e7891051662a32fc6bddcc1"


### PR DESCRIPTION
fixes #89 

I tested that this works by creating an .env file with

```
MM_DEV=1
```

then deleting that definition from dev.js, running `yarn dev` and making sure MM_DEV gets set.