### PR TITLE
correct link name in header path

### DIFF
--- a/packages/cli/src/components/Header.tsx
+++ b/packages/cli/src/components/Header.tsx
@@ -29,7 +29,7 @@ const Header: React.FC<HeaderProps> = ({
       <div className="path">
         <Link href="/">
           <a className="index">
-            <span>Index</span>
+            <span>previews</span>
           </a>
         </Link>
         <span> / {title}</span>


### PR DESCRIPTION
"Index" -> "previews" ... thought i had done this in the html-ui branch but looks like i missed it

<img width="295" alt="Screen Shot 2022-08-07 at 9 26 18 AM" src="https://user-images.githubusercontent.com/609038/183300997-0c4c9a8b-0116-4019-85ef-22d2e8b293d3.png">

