### PR TITLE
Fix images in module build

### DIFF
--- a/.changeset/happy-carrots-report.md
+++ b/.changeset/happy-carrots-report.md
@@ -1,0 +1,5 @@
+---
+"mailing": patch
+---
+
+fix broken images

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "devjs": "rm -rf emails; ln -s packages/cli/src/generator_templates/js/emails emails; packages/cli/src/dev.js",
     "build": "preconstruct build && yarn build:next && yarn copy:files",
     "build:next": "cd packages/cli && yarn build",
-    "copy:files": "cp -nR packages/cli/src/generator_templates packages/cli/dist; cp -nR packages/cli/.next packages/cli/dist; rm -rf packages/cli/dist/.next/cache",
+    "copy:files": "cp -nR packages/cli/src/generator_templates packages/cli/dist; cp -nR packages/cli/.next packages/cli/dist; cp -nR packages/cli/public packages/cli/dist; rm -rf packages/cli/dist/.next/cache",
     "test": "jest",
     "test:watch": "jest --watch",
     "prepublish": "yarn build",


### PR DESCRIPTION
Copies in the public folder so that images work correctly since we moved them.

Tested via yalc in a nextjs app.