### PR TITLE
fix(hotkeys): remap view hotkeys, add previous mode hotkey

### DIFF
--- a/packages/cli/src/components/Intercept.tsx
+++ b/packages/cli/src/components/Intercept.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
-import HotIFrame from "./HotIFrame";
+import { hotkeysMap } from "./hooks/usePreviewHotkeys";
 import Header from "./Header";
+import HotIFrame from "./HotIFrame";
 
 type InterceptProps = {
   data?: Intercept;
@@ -22,23 +23,27 @@ const Intercept: React.FC<InterceptProps> = ({ data }) => {
           <>
             <div className="title">Hotkeys</div>
             <div className="hotkey">
-              <span className="character">/</span>
+              <span className="character">{hotkeysMap.showPreviews}</span>
               <span className="description">Jump to previews</span>
             </div>
             <div className="hotkey">
-              <span className="character">.</span>
-              <span className="description">Toggle view mode</span>
+              <span className="character">{hotkeysMap.viewModeNext}</span>
+              <span className="description">Next view mode</span>
             </div>
             <div className="hotkey">
-              <span className="character">D</span>
+              <span className="character">{hotkeysMap.viewModePrevious}</span>
+              <span className="description">Previous view mode</span>
+            </div>
+            <div className="hotkey">
+              <span className="character">{hotkeysMap.viewModeDesktop}</span>
               <span className="description">Desktop view</span>
             </div>
             <div className="hotkey">
-              <span className="character">M</span>
+              <span className="character">{hotkeysMap.viewModeMobile}</span>
               <span className="description">Mobile view</span>
             </div>
             <div className="hotkey">
-              <span className="character">H</span>
+              <span className="character">{hotkeysMap.viewModeHTML}</span>
               <span className="description">HTML view</span>
             </div>
           </>

--- a/packages/cli/src/components/hooks/usePreviewHotkeys.tsx
+++ b/packages/cli/src/components/hooks/usePreviewHotkeys.tsx
@@ -6,36 +6,51 @@ type Options = {
   setViewMode: React.Dispatch<React.SetStateAction<ViewMode>>;
 };
 
+const hotkeysMap = {
+  showPreviews: '/',
+  viewModeDesktop: '1',
+  viewModeHTML: '3',
+  viewModeMobile: '2',
+  viewModeNext: ']',
+  viewModePrevious: '[',
+};
+
+const viewModeOrder: ViewMode[] = ['desktop', 'mobile', 'html']
+
 // Hotkeys for pages showing previews / intercepts
 // Listen for hotkeys on the document and the iframe's
 // document, so that they still work if iframe has focus.
 export default function usePreviewHotkeys({ setViewMode }: Options) {
   const router = useRouter();
-  const handleKey = useCallback(
-    (e: KeyboardEvent) => {
-      if (e.key === "/") {
+  const handleKey = useCallback((e: KeyboardEvent) => {
+    switch (e.key) {
+      case hotkeysMap.showPreviews:
         router.push("/");
-      } else if (e.key === "m") {
-        setViewMode("mobile");
-      } else if (e.key === "h") {
-        setViewMode("html");
-      } else if (e.key === "d") {
+        break;
+      case hotkeysMap.viewModeDesktop:
         setViewMode("desktop");
-      } else if (e.key === ".") {
-        setViewMode((current) =>
-          current === "desktop"
-            ? "mobile"
-            : current === "mobile"
-            ? "html"
-            : "desktop"
-        );
-      } else if (e.key === "ArrowRight" || e.key === "right") {
-      } else if (e.key === "ArrowLeft" || e.key === "left") {
-      }
-    },
-    [router, setViewMode]
-  );
-  useHotkeys("m,d,h,.,left,right,/", handleKey);
+        break;
+      case hotkeysMap.viewModeHTML:
+        setViewMode("html");
+        break;
+      case hotkeysMap.viewModeMobile:
+        setViewMode("mobile");
+        break;
+      case hotkeysMap.viewModeNext:
+        setViewMode((viewMode) => {
+          const nextIndex = viewModeOrder.indexOf(viewMode) + 1;
+          return viewModeOrder[nextIndex] || viewModeOrder[0];
+        });
+        break;
+      case hotkeysMap.viewModePrevious:
+        setViewMode((viewMode) => {
+          const nextIndex = viewModeOrder.indexOf(viewMode) - 1;
+          return viewModeOrder[nextIndex] || viewModeOrder[viewModeOrder.length - 1];
+        });
+        break;
+    }
+  }, [router, setViewMode]);
+  useHotkeys(Object.values(hotkeysMap).join(','), handleKey);
 
   const iframeRef = useCallback(
     (node: HTMLIFrameElement) => {

--- a/packages/cli/src/components/hooks/usePreviewHotkeys.tsx
+++ b/packages/cli/src/components/hooks/usePreviewHotkeys.tsx
@@ -6,7 +6,7 @@ type Options = {
   setViewMode: React.Dispatch<React.SetStateAction<ViewMode>>;
 };
 
-const hotkeysMap = {
+export const hotkeysMap = {
   showPreviews: '/',
   viewModeDesktop: '1',
   viewModeHTML: '3',

--- a/packages/cli/src/pages/previews/[previewClass]/[previewFunction].tsx
+++ b/packages/cli/src/pages/previews/[previewClass]/[previewFunction].tsx
@@ -4,6 +4,7 @@ import Header from "../../../components/Header";
 import HotIFrame from "../../../components/HotIFrame";
 import MjmlErrors from "../../../components/MjmlErrors";
 import { GetStaticProps } from "next";
+import { hotkeysMap } from "../../../components/hooks/usePreviewHotkeys";
 
 type Params = { previewClass: string; previewFunction: string };
 
@@ -95,23 +96,27 @@ const Preview = ({ initialData }: { initialData: ShowPreviewResponseBody }) => {
           <>
             <div className="title">Hotkeys</div>
             <div className="hotkey">
-              <span className="character">/</span>
+              <span className="character">{hotkeysMap.showPreviews}</span>
               <span className="description">Jump to previews</span>
             </div>
             <div className="hotkey">
-              <span className="character">.</span>
-              <span className="description">Toggle view mode</span>
+              <span className="character">{hotkeysMap.viewModeNext}</span>
+              <span className="description">Next view mode</span>
             </div>
             <div className="hotkey">
-              <span className="character">D</span>
+              <span className="character">{hotkeysMap.viewModePrevious}</span>
+              <span className="description">Previous view mode</span>
+            </div>
+            <div className="hotkey">
+              <span className="character">{hotkeysMap.viewModeDesktop}</span>
               <span className="description">Desktop view</span>
             </div>
             <div className="hotkey">
-              <span className="character">M</span>
+              <span className="character">{hotkeysMap.viewModeMobile}</span>
               <span className="description">Mobile view</span>
             </div>
             <div className="hotkey">
-              <span className="character">H</span>
+              <span className="character">{hotkeysMap.viewModeHTML}</span>
               <span className="description">HTML view</span>
             </div>
           </>


### PR DESCRIPTION
- refactor hotkeys to make adding more views easier (such as https://github.com/sofn-xyz/mailing/tree/gh/119-text-previews)
- add the option to jump to the previous view mode (using `[`)
- remap the option to jump to the next view mode (using `]`)
- remap the view mode keys to use more standard pattern (using `1`, `2`, `3`)