### PR TITLE
add mailing-core to README and note:

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,7 +40,7 @@ export async function clearTestMailQueue() {
 
   try {
     await fs.unlinkSync(TMP_TEST_FILE);
-  } catch (e: any) {
+  } catch (e) {
     if (e.code === "ENOENT") return; // file does not exist
     throw e;
   }


### PR DESCRIPTION
Note: you may want to add mailing as a dev dependency instead if you don't plan to use the preview function outside of development.  mailing-core exports buildSendMail, which returns the sendMail function