### PR TITLE
close hamburger menu when selecting email

### DIFF
--- a/packages/cli/src/components/IndexPane/CompactView.tsx
+++ b/packages/cli/src/components/IndexPane/CompactView.tsx
@@ -8,7 +8,7 @@ type CompactViewProps = {
   cursor: number;
   navigate: (nextCursor: number | ((current: number) => number)) => void;
   setCollapse: (cursor: number, collapse: boolean) => void;
-  setHamburgerOpen?: Function;
+  setHamburgerOpen?: (open: boolean) => void;
 };
 
 const CompactView: React.FC<CompactViewProps> = ({

--- a/packages/cli/src/components/IndexPane/CompactView.tsx
+++ b/packages/cli/src/components/IndexPane/CompactView.tsx
@@ -8,6 +8,7 @@ type CompactViewProps = {
   cursor: number;
   navigate: (nextCursor: number | ((current: number) => number)) => void;
   setCollapse: (cursor: number, collapse: boolean) => void;
+  setHamburgerOpen: Function;
 };
 
 const CompactView: React.FC<CompactViewProps> = ({
@@ -15,13 +16,15 @@ const CompactView: React.FC<CompactViewProps> = ({
   cursor,
   navigate,
   setCollapse,
+  setHamburgerOpen,
 }) => {
   const handleClick = useCallback(
     (i: number, collapsed: boolean) => (e: React.MouseEvent<HTMLDivElement>) => {
       setCollapse(i, !collapsed);
       navigate(i);
+      setHamburgerOpen(false);
     },
-    [navigate, setCollapse]
+    [navigate, setCollapse, setHamburgerOpen]
   );
 
   let collapseLevel = 999;

--- a/packages/cli/src/components/IndexPane/CompactView.tsx
+++ b/packages/cli/src/components/IndexPane/CompactView.tsx
@@ -8,7 +8,7 @@ type CompactViewProps = {
   cursor: number;
   navigate: (nextCursor: number | ((current: number) => number)) => void;
   setCollapse: (cursor: number, collapse: boolean) => void;
-  setHamburgerOpen: Function;
+  setHamburgerOpen?: Function;
 };
 
 const CompactView: React.FC<CompactViewProps> = ({
@@ -22,7 +22,9 @@ const CompactView: React.FC<CompactViewProps> = ({
     (i: number, collapsed: boolean) => (e: React.MouseEvent<HTMLDivElement>) => {
       setCollapse(i, !collapsed);
       navigate(i);
-      setHamburgerOpen(false);
+      if (typeof setHamburgerOpen == "function") {
+        setHamburgerOpen(false);
+      }
     },
     [navigate, setCollapse, setHamburgerOpen]
   );

--- a/packages/cli/src/components/IndexPane/IndexPane.tsx
+++ b/packages/cli/src/components/IndexPane/IndexPane.tsx
@@ -11,7 +11,7 @@ import type { PreviewIndexResponseBody } from "../../pages/api/previews";
 type IndexPaneProps = {
   previews?: PreviewIndexResponseBody["previews"];
   previewText?: PreviewIndexResponseBody["previewText"];
-  setHamburgerOpen: Function;
+  setHamburgerOpen?: Function;
 };
 
 const IndexPane: React.FC<IndexPaneProps> = ({

--- a/packages/cli/src/components/IndexPane/IndexPane.tsx
+++ b/packages/cli/src/components/IndexPane/IndexPane.tsx
@@ -11,7 +11,7 @@ import type { PreviewIndexResponseBody } from "../../pages/api/previews";
 type IndexPaneProps = {
   previews?: PreviewIndexResponseBody["previews"];
   previewText?: PreviewIndexResponseBody["previewText"];
-  setHamburgerOpen?: Function;
+  setHamburgerOpen?: (open: boolean) => void;
 };
 
 const IndexPane: React.FC<IndexPaneProps> = ({

--- a/packages/cli/src/components/IndexPane/IndexPane.tsx
+++ b/packages/cli/src/components/IndexPane/IndexPane.tsx
@@ -11,9 +11,14 @@ import type { PreviewIndexResponseBody } from "../../pages/api/previews";
 type IndexPaneProps = {
   previews?: PreviewIndexResponseBody["previews"];
   previewText?: PreviewIndexResponseBody["previewText"];
+  setHamburgerOpen: Function;
 };
 
-const IndexPane: React.FC<IndexPaneProps> = ({ previews, previewText }) => {
+const IndexPane: React.FC<IndexPaneProps> = ({
+  previews,
+  previewText,
+  setHamburgerOpen,
+}) => {
   const [compact, setCompact] = useState(true);
   const { up, down, left, right, treeRoutes, cursor, navigate, setCollapse } =
     usePreviewTree(previews || [], { leavesOnly: !compact });
@@ -47,6 +52,7 @@ const IndexPane: React.FC<IndexPaneProps> = ({ previews, previewText }) => {
       cursor={cursor}
       navigate={navigate}
       setCollapse={setCollapse}
+      setHamburgerOpen={setHamburgerOpen}
     />
   ) : (
     <ClientView

--- a/packages/cli/src/components/MjmlErrors.tsx
+++ b/packages/cli/src/components/MjmlErrors.tsx
@@ -5,7 +5,7 @@ type MjmlErrorsProps = {
 const MjmlErrors: React.FC<MjmlErrorsProps> = ({ errors }) => {
   return (
     <>
-      <div className="mjmlErrors">
+      <div className="bg-red font-white p-24">
         <h1>MJML Errors</h1>
         <div>
           Please resolve the following MJML errors in your email before
@@ -17,13 +17,6 @@ const MjmlErrors: React.FC<MjmlErrorsProps> = ({ errors }) => {
           ))}
         </ul>
       </div>
-      <style jsx>{`
-        .mjmlErrors {
-          padding: 100px;
-          background: red;
-          color: white;
-        }
-      `}</style>
     </>
   );
 };

--- a/packages/cli/src/components/MobileHeader.tsx
+++ b/packages/cli/src/components/MobileHeader.tsx
@@ -1,17 +1,13 @@
-import { ReactElement } from "react";
-import IconCode from "./icons/IconCode";
-import IconMobile from "./icons/IconMobile";
-import IconDesktop from "./icons/IconDesktop";
 import Image from "next/image";
 import cx from "classnames";
 
-type HeaderProps = {
+type MobileHeaderProps = {
   title: string;
   hamburgerOpen: boolean;
   setHamburgerOpen: (open: boolean) => void;
 };
 
-const Header: React.FC<HeaderProps> = ({
+const MobileHeader: React.FC<MobileHeaderProps> = ({
   title,
   hamburgerOpen,
   setHamburgerOpen,
@@ -74,4 +70,4 @@ const Header: React.FC<HeaderProps> = ({
   );
 };
 
-export default Header;
+export default MobileHeader;

--- a/packages/cli/src/components/PreviewViewer.tsx
+++ b/packages/cli/src/components/PreviewViewer.tsx
@@ -85,7 +85,11 @@ const PreviewViewer: React.FC<PreviewViewerProps> = ({ initialData }) => {
             }
           )}
         >
-          <IndexPane previews={previews} previewText={data?.previewText} />
+          <IndexPane
+            previews={previews}
+            previewText={data?.previewText}
+            setHamburgerOpen={setHamburgerOpen}
+          />
         </div>
         <div className="right-pane sm:left-[300px] sm:w-[calc(100vw-300px)]">
           {!!preview?.errors?.length && <MjmlErrors errors={preview?.errors} />}


### PR DESCRIPTION
## Describe your changes
- Close hamburger menu when selecting an email.
- Changes component name of MobileHeader to work better with React Dev Tools
- Updates MjmlError to use tailwind directly.


## Issue link
#219 

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] If it is a core feature, I have added thorough tests.
