### PR TITLE
fix crashes when current preview class or function name are changed

### DIFF
--- a/.changeset/cold-tomatoes-melt.md
+++ b/.changeset/cold-tomatoes-melt.md
@@ -1,0 +1,7 @@
+---
+"mailing": patch
+"mailing-core": patch
+"web": patch
+---
+
+bugfix for issues with changing preview names #237

--- a/packages/cli/src/components/PreviewViewer.tsx
+++ b/packages/cli/src/components/PreviewViewer.tsx
@@ -28,7 +28,7 @@ async function fetchJson(url: string) {
   const response = await fetch(url, {
     headers: { "Content-Type": "application/json" },
   });
-  return await response.json();
+  return response.status === 200 ? response.json() : {};
 }
 
 const PreviewViewer: React.FC<PreviewViewerProps> = ({ initialData }) => {

--- a/packages/cli/src/pages/api/previews/index.ts
+++ b/packages/cli/src/pages/api/previews/index.ts
@@ -29,7 +29,9 @@ function getPreviewFunction(
 ): [string, string] {
   let text = "";
   try {
-    const { html } = render(getPreviewComponent(previewClass, name));
+    const component = getPreviewComponent(previewClass, name);
+    if (!component) throw new Error(`${previewClass}#${name} not found`);
+    const { html } = render(component);
     // slice out the body to minimize funky head parsing
     const body = /<body[^>]*>((.|[\n\r])*)<\/body>/im.exec(html);
     if (body && body[1]) {

--- a/packages/cli/src/pages/previews/[[...path]].tsx
+++ b/packages/cli/src/pages/previews/[[...path]].tsx
@@ -10,6 +10,7 @@ import PreviewViewer, {
 } from "../../components/PreviewViewer";
 import { flatten } from "lodash";
 import { render } from "../../util/mjml";
+import { log } from "src/util/log";
 
 type Params = { path: string[] };
 
@@ -42,6 +43,17 @@ export const getStaticProps: GetStaticProps = async (context) => {
   let preview = null;
   if (previewClass && previewFunction) {
     const component = getPreviewComponent(previewClass, previewFunction);
+    if (!component) {
+      log(
+        `${previewClass} or ${previewFunction} not found, redirecting to home`
+      );
+      return {
+        redirect: {
+          destination: "/",
+          permanent: false,
+        },
+      };
+    }
     preview = render(component);
   }
 

--- a/packages/cli/src/util/config/__test__/config.test.ts
+++ b/packages/cli/src/util/config/__test__/config.test.ts
@@ -5,6 +5,9 @@ import {
   defaults,
   looksLikeTypescriptProject,
   writeDefaultConfigFile,
+  setConfig,
+  getConfig,
+  getQuiet,
 } from "..";
 
 jest.mock("../../log");
@@ -149,5 +152,22 @@ describe("writeDefaultConfigFile", () => {
     expect(mockReadJSONWithBlankString).toHaveBeenCalled();
     expect(mockWriteFileSync).not.toHaveBeenCalled();
     expect(log).not.toHaveBeenCalled();
+  });
+
+  describe("getQuiet", () => {
+    it("works if config is defined", () => {
+      setConfig(undefined);
+      expect(getConfig).toThrow();
+      setConfig({ quiet: true, port: 3456, emailsDir: "emails" });
+      expect(getConfig).not.toThrow();
+      expect(getQuiet()).toBe(true);
+      setConfig({ quiet: false, port: 3456, emailsDir: "emails" });
+      expect(getQuiet()).toBe(false);
+    });
+    it("works even if config is undefined", () => {
+      setConfig(undefined);
+      expect(getConfig).toThrow();
+      expect(getQuiet()).toBe(false);
+    });
   });
 });

--- a/packages/cli/src/util/config/index.ts
+++ b/packages/cli/src/util/config/index.ts
@@ -143,3 +143,8 @@ export function getConfig(): Config {
   }
   return config;
 }
+
+// This method is useful in cases that config may not be set (like logging on the front-end).
+export function getQuiet(): boolean {
+  return !!config?.quiet;
+}

--- a/packages/cli/src/util/config/index.ts
+++ b/packages/cli/src/util/config/index.ts
@@ -133,7 +133,7 @@ type Config = {
 
 let config: Config | undefined;
 
-export function setConfig(newConfig: Config) {
+export function setConfig(newConfig: typeof config) {
   config = newConfig;
 }
 

--- a/packages/cli/src/util/log.ts
+++ b/packages/cli/src/util/log.ts
@@ -1,12 +1,12 @@
 import chalk from "chalk";
-import { getConfig } from "./config";
+import { getQuiet } from "./config";
 
 const { DEBUG } = process.env;
 
 const PREFIX = "mailing";
 
 export function log(message?: any, ...optionalParams: any[]) {
-  if (getConfig().quiet && !debug) return;
+  if (getQuiet() && !DEBUG) return;
   console.log(chalk.white(PREFIX), message, ...optionalParams);
 }
 
@@ -20,6 +20,6 @@ export function debug(message?: any, ...optionalParams: any[]) {
 }
 
 export function logPlain(message?: any, ...optionalParams: any[]) {
-  if (getConfig().quiet && !debug) return;
+  if (getQuiet() && !DEBUG) return;
   console.log(message, ...optionalParams);
 }

--- a/packages/cli/src/util/moduleManifestUtil.ts
+++ b/packages/cli/src/util/moduleManifestUtil.ts
@@ -1,4 +1,4 @@
-import { ReactElement } from "react";
+import { JSXElementConstructor, ReactElement } from "react";
 import { previews, config } from "../moduleManifest";
 
 export function previewTree(): [string, string[]][] {
@@ -12,11 +12,16 @@ export function getPreviewModule(name: string) {
   return previews[name as keyof typeof previews];
 }
 
-export function getPreviewComponent(name: string, functionName: string) {
-  const previewModule: {
-    [key: string]: () => ReactElement;
-  } = previews[name as keyof typeof previews] as any;
-  return previewModule?.[functionName]();
+export function getPreviewComponent(
+  name: string,
+  functionName: string
+): ReactElement<any, string | JSXElementConstructor<any>> | undefined {
+  const previewModule:
+    | {
+        [key: string]: () => ReactElement | undefined;
+      }
+    | undefined = previews[name as keyof typeof previews] as any;
+  return previewModule?.[functionName]?.();
 }
 
 export function getConfig(): MailingConfig {

--- a/packages/cli/src/util/moduleManifestUtil.ts
+++ b/packages/cli/src/util/moduleManifestUtil.ts
@@ -16,7 +16,7 @@ export function getPreviewComponent(name: string, functionName: string) {
   const previewModule: {
     [key: string]: () => ReactElement;
   } = previews[name as keyof typeof previews] as any;
-  return previewModule[functionName]();
+  return previewModule?.[functionName]();
 }
 
 export function getConfig(): MailingConfig {


### PR DESCRIPTION
## Describe your changes

There were runtime errors when you change the names of preview classes or preview functions.

- fix that by allowing for missed in moduleManifestUtil, fix associated types, fix callsites
- switch logger to use getQuiet which is safe if config is not set (like when logging on front-end).

It would be a good thing to test in a more e2e way at some point but I think type fixes + unit tests are ok for now.

I manually verified this fix by installing my build in a local instance of dub and mucking with preview class and preview function names.

## Issue link

#237 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
