### PR TITLE
switch to importing assert rather than node:assert for node 14 compatibility

### DIFF
--- a/.changeset/khaki-weeks-hear.md
+++ b/.changeset/khaki-weeks-hear.md
@@ -1,0 +1,6 @@
+---
+"mailing": patch
+"mailing-core": patch
+---
+
+bugfix assert for node 14 compatibility

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -6,7 +6,7 @@ import { buildHandler } from "../util/buildHandler";
 import { execSync } from "child_process";
 import { resolve } from "path";
 import * as prettier from "prettier";
-import assert from "node:assert";
+import { strict as assert } from "assert";
 
 export type DeployArgs = ArgumentsCamelCase<{
   emailsDir?: string;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -110,7 +110,11 @@ export function buildSendMail(options: BuildSendMailOptions) {
     }
 
     if (forcePreview) {
-      log("💌 opening sendMail preview", mail);
+      const debugMail = {
+        ...mail,
+        html: "omitted",
+      };
+      log("💌 opening sendMail preview", debugMail);
       // create an intercept on the preview server
       // then open it in the browser
       const PREVIEW_SERVER_URL = "http://localhost:3883/intercepts";


### PR DESCRIPTION
## Describe your changes

This fixes the build for node 14. I tested locally on 14, 16, 18 that this works.

`npx mailing deploy` is broken on 14 though because of a change to how npx handles `--yes`. I have a better idea for the deploy command, will fix that soon.

## Issue link

reported by lc on discord

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
