### PR TITLE
remove semicolon; fix layout scroll/height bug

### DIFF
--- a/.changeset/plenty-toys-talk.md
+++ b/.changeset/plenty-toys-talk.md
@@ -1,0 +1,6 @@
+---
+"mailing": patch
+"mailing-core": patch
+---
+
+fix layout bugs

--- a/packages/cli/src/components/HotIFrame.tsx
+++ b/packages/cli/src/components/HotIFrame.tsx
@@ -22,7 +22,7 @@ const HotIFrame: React.FC<HotIFrameProps> = ({
         <textarea
           className={cx("code-container mono text-black", {
             "fixed top-0 left-0 right-0 bottom-0 z-50 h-full": fullScreen,
-            "h-[calc(100vh-53px)]": !fullScreen,
+            "h-[calc(100vh-52px)]": !fullScreen,
           })}
           readOnly
           value={srcDoc}
@@ -43,7 +43,7 @@ const HotIFrame: React.FC<HotIFrameProps> = ({
               className={cx("bg-neutral-50", {
                 "fixed top-0 left-0 right-0 bottom-0 z-50 h-full":
                   fullScreen && viewMode !== "mobile",
-                "h-[calc(100vh-53px)]": !fullScreen,
+                "h-[calc(100vh-52px)]": !fullScreen,
               })}
               srcDoc={srcDoc}
               ref={iframeRef}

--- a/packages/cli/src/components/HotIFrame.tsx
+++ b/packages/cli/src/components/HotIFrame.tsx
@@ -20,30 +20,27 @@ const HotIFrame: React.FC<HotIFrameProps> = ({
     <>
       {viewMode === "html" ? (
         <textarea
-          className={cx("code-container mono text-black", {
-            "fixed top-0 left-0 right-0 bottom-0 z-50 h-full": fullScreen,
-            "h-[calc(100vh-52px)]": !fullScreen,
+          className={cx("code-container mono text-black h-full", {
+            "fixed top-0 left-0 right-0 bottom-0 z-50": fullScreen,
           })}
           readOnly
           value={srcDoc}
         ></textarea>
       ) : (
         <div
-          className={cx({
-            "fixed top-0 left-0 right-0 bottom-0 z-50 h-full bg-black":
-              fullScreen,
+          className={cx("h-full", {
+            "fixed top-0 left-0 right-0 bottom-0 z-50 bg-black": fullScreen,
           })}
         >
           <div
-            className={cx("frame", {
+            className={cx("frame h-full", {
               mobile: viewMode === "mobile",
             })}
           >
             <iframe
-              className={cx("bg-neutral-50", {
-                "fixed top-0 left-0 right-0 bottom-0 z-50 h-full":
+              className={cx("bg-neutral-50 h-full", {
+                "fixed top-0 left-0 right-0 bottom-0 z-50":
                   fullScreen && viewMode !== "mobile",
-                "h-[calc(100vh-52px)]": !fullScreen,
               })}
               srcDoc={srcDoc}
               ref={iframeRef}

--- a/packages/cli/src/components/Intercept.tsx
+++ b/packages/cli/src/components/Intercept.tsx
@@ -51,7 +51,7 @@ const Intercept: React.FC<InterceptProps> = ({ data }) => {
   }
 
   return (
-    <>
+    <div className="h-screen flex flex-col">
       <Header
         setViewMode={setViewMode}
         viewMode={viewMode}
@@ -122,13 +122,15 @@ const Intercept: React.FC<InterceptProps> = ({ data }) => {
           </button>
         </div>
       </div>
-      {data.html && (
-        <HotIFrame
-          viewMode={viewMode}
-          setViewMode={setViewMode}
-          srcDoc={data.html}
-        />
-      )}
+      <div className="flex-1">
+        {data.html && (
+          <HotIFrame
+            viewMode={viewMode}
+            setViewMode={setViewMode}
+            srcDoc={data.html}
+          />
+        )}
+      </div>
       <style jsx>{`
         .container {
           border-bottom: dotted 1px #333;
@@ -156,7 +158,7 @@ const Intercept: React.FC<InterceptProps> = ({ data }) => {
           top: 1.25px;
         }
       `}</style>
-    </>
+    </div>
   );
 };
 

--- a/packages/cli/src/components/MjmlErrors.tsx
+++ b/packages/cli/src/components/MjmlErrors.tsx
@@ -4,20 +4,17 @@ type MjmlErrorsProps = {
 
 const MjmlErrors: React.FC<MjmlErrorsProps> = ({ errors }) => {
   return (
-    <>
-      <div className="bg-red font-white p-24">
-        <h1>MJML Errors</h1>
-        <div>
-          Please resolve the following MJML errors in your email before
-          continuing
-        </div>
-        <ul>
-          {errors.map((error, i) => (
-            <li key={`error${i}`}>{error.formattedMessage}</li>
-          ))}
-        </ul>
+    <div className="bg-red font-white p-24">
+      <h1>MJML Errors</h1>
+      <div>
+        Please resolve the following MJML errors in your email before continuing
       </div>
-    </>
+      <ul>
+        {errors.map((error, i) => (
+          <li key={`error${i}`}>{error.formattedMessage}</li>
+        ))}
+      </ul>
+    </div>
   );
 };
 

--- a/packages/cli/src/components/MobileHeader.tsx
+++ b/packages/cli/src/components/MobileHeader.tsx
@@ -23,7 +23,7 @@ const MobileHeader: React.FC<MobileHeaderProps> = ({ title }) => {
       <div>
         <nav>
           <button
-            className="w-14 h-[53px] relative focus:outline-none"
+            className="w-14 h-[52px] relative focus:outline-none"
             onClick={() => setHamburgerOpen(!hamburgerOpen)}
           >
             <span

--- a/packages/cli/src/components/PreviewViewer.tsx
+++ b/packages/cli/src/components/PreviewViewer.tsx
@@ -88,7 +88,7 @@ const PreviewViewer: React.FC<PreviewViewerProps> = ({ initialData }) => {
         >
           <IndexPane previews={previews} previewText={data?.previewText} />
         </div>
-        <div className="right-pane sm:left-[300px] sm:w-[calc(100vw-300px)] sm:h-[calc(100vh-52px)]">
+        <div className="right-pane sm:left-[300px] sm:w-[calc(100vw-300px)]">
           {!!preview?.errors?.length && <MjmlErrors errors={preview?.errors} />}
           <div className="sm:hidden">
             <MobileHeader title={previewFunction || previewClass || "Emails"} />

--- a/packages/cli/src/components/PreviewViewer.tsx
+++ b/packages/cli/src/components/PreviewViewer.tsx
@@ -74,104 +74,104 @@ const PreviewViewer: React.FC<PreviewViewerProps> = ({ initialData }) => {
   const { preview, previews } = data || { preview: null, previews: [] };
 
   return (
-    <div>
-      <div>
-        <div
-          className={cx(
-            "left-pane absolute border-dotted border-r border-gray-600 w-full sm:w-[300px] sm:left-0 transition-all z-40 bg-black mt-[52px] sm:mt-0",
-            {
-              "opacity-100": hamburgerOpen,
-              "opacity-0 sm:opacity-100 pointer-events-none sm:pointer-events-auto":
-                !hamburgerOpen,
-            }
-          )}
-        >
-          <IndexPane previews={previews} previewText={data?.previewText} />
+    <div className="h-screen">
+      <div
+        className={cx(
+          "left-pane absolute border-dotted border-r border-gray-600 w-full sm:w-[300px] sm:left-0 transition-all z-40 bg-black mt-[52px] sm:mt-0",
+          {
+            "opacity-100": hamburgerOpen,
+            "opacity-0 sm:opacity-100 pointer-events-none sm:pointer-events-auto":
+              !hamburgerOpen,
+          }
+        )}
+      >
+        <IndexPane previews={previews} previewText={data?.previewText} />
+      </div>
+      <div className="right-pane sm:left-[300px] sm:w-[calc(100vw-300px)] h-full flex flex-col">
+        {!!preview?.errors?.length && <MjmlErrors errors={preview?.errors} />}
+        <div className="sm:hidden">
+          <MobileHeader title={previewFunction || previewClass || "Emails"} />
         </div>
-        <div className="right-pane sm:left-[300px] sm:w-[calc(100vw-300px)]">
-          {!!preview?.errors?.length && <MjmlErrors errors={preview?.errors} />}
-          <div className="sm:hidden">
-            <MobileHeader title={previewFunction || previewClass || "Emails"} />
-          </div>
-          {preview?.html && !preview?.errors.length ? (
-            <>
-              <div className="hidden sm:block">
-                <Header
-                  previewClass={previewClass as string}
-                  previewFunction={
-                    previewFunction ? (previewFunction as string) : undefined
-                  }
-                  viewMode={viewMode}
-                  setViewMode={setViewMode}
-                  helpContent={
-                    <div
-                      className="text-xs w-[190px] space-y-2"
-                      aria-label="hotkeys"
-                    >
-                      <div className="hotkey flex justify-between">
-                        <span className="description">Toggle compact view</span>
-                        <span className="character">{"`"}</span>
-                      </div>
-                      <div className="hotkey flex justify-between">
-                        <span className="description">Desktop view</span>
+        {preview?.html && !preview?.errors.length ? (
+          <>
+            <div className="hidden sm:block">
+              <Header
+                previewClass={previewClass as string}
+                previewFunction={
+                  previewFunction ? (previewFunction as string) : undefined
+                }
+                viewMode={viewMode}
+                setViewMode={setViewMode}
+                helpContent={
+                  <div
+                    className="text-xs w-[190px] space-y-2"
+                    aria-label="hotkeys"
+                  >
+                    <div className="hotkey flex justify-between">
+                      <span className="description">Toggle compact view</span>
+                      <span className="character">{"`"}</span>
+                    </div>
+                    <div className="hotkey flex justify-between">
+                      <span className="description">Desktop view</span>
+                      <span className="character">
+                        {hotkeysMap.viewModeDesktop}
+                      </span>
+                    </div>
+                    <div className="hotkey flex justify-between">
+                      <span className="description">Mobile view</span>
+                      <span className="character">
+                        {hotkeysMap.viewModeMobile}
+                      </span>
+                    </div>
+                    <div className="hotkey flex justify-between">
+                      <span className="description">HTML view</span>
+                      <span className="character">
+                        {hotkeysMap.viewModeHTML}
+                      </span>
+                    </div>
+                    <div className="hotkey flex justify-between">
+                      <span className="description">Next view mode</span>
+                      <span className="character">
+                        {hotkeysMap.viewModeNext}
+                      </span>
+                    </div>
+                    <div className="hotkey flex justify-between">
+                      <span className="description">Previous view mode</span>
+                      <span className="character">
+                        {hotkeysMap.viewModePrevious}
+                      </span>
+                    </div>
+                    <div className="hotkey flex justify-between">
+                      <span className="description">Toggle full screen</span>
+                      <div>
+                        <span className="character">&#8984;</span>
                         <span className="character">
-                          {hotkeysMap.viewModeDesktop}
+                          {hotkeysMap.toggleFullScreen.split("+")[1]}
                         </span>
-                      </div>
-                      <div className="hotkey flex justify-between">
-                        <span className="description">Mobile view</span>
-                        <span className="character">
-                          {hotkeysMap.viewModeMobile}
-                        </span>
-                      </div>
-                      <div className="hotkey flex justify-between">
-                        <span className="description">HTML view</span>
-                        <span className="character">
-                          {hotkeysMap.viewModeHTML}
-                        </span>
-                      </div>
-                      <div className="hotkey flex justify-between">
-                        <span className="description">Next view mode</span>
-                        <span className="character">
-                          {hotkeysMap.viewModeNext}
-                        </span>
-                      </div>
-                      <div className="hotkey flex justify-between">
-                        <span className="description">Previous view mode</span>
-                        <span className="character">
-                          {hotkeysMap.viewModePrevious}
-                        </span>
-                      </div>
-                      <div className="hotkey flex justify-between">
-                        <span className="description">Toggle full screen</span>
-                        <div>
-                          <span className="character">&#8984;</span>
-                          <span className="character">
-                            {hotkeysMap.toggleFullScreen.split("+")[1]}
-                          </span>
-                        </div>
                       </div>
                     </div>
-                  }
-                />
-              </div>
+                  </div>
+                }
+              />
+            </div>
+            <div className="flex-1">
               <HotIFrame
                 srcDoc={preview.html}
                 viewMode={viewMode}
                 setViewMode={setViewMode}
               />
-            </>
-          ) : (
-            <div className="text-2xl grid h-screen place-items-center text-gray-600">
-              No preview selected
             </div>
-          )}
-          {fetching && (
-            <div className="loader-position">
-              <CircleLoader />
-            </div>
-          )}
-        </div>
+          </>
+        ) : (
+          <div className="text-2xl grid h-screen place-items-center text-gray-600">
+            No preview selected
+          </div>
+        )}
+        {fetching && (
+          <div className="loader-position">
+            <CircleLoader />
+          </div>
+        )}
       </div>
 
       <style jsx>{`

--- a/packages/cli/src/components/Tooltip.tsx
+++ b/packages/cli/src/components/Tooltip.tsx
@@ -57,7 +57,7 @@ const Tooltip: React.FC<TooltipProps> = ({ content, trigger }) => {
         }
         .overlay {
           position: absolute;
-          top: 53px;
+          top: 52px;
           right: 0;
           left: 0;
           bottom: 0;

--- a/packages/cli/src/pages/_app.tsx
+++ b/packages/cli/src/pages/_app.tsx
@@ -9,7 +9,7 @@ export default function Mailing({ Component, pageProps }: AppProps) {
       <Head>
         <title>Mailing</title>
       </Head>
-      <Component {...pageProps} />;
+      <Component {...pageProps} />
     </HamburgerProvider>
   );
 }


### PR DESCRIPTION
## Describe your changes

Not sure when this happened, but the layout broke for preview mode.

This makes it a bit less brittle by doing less hardcoding of the header height.

Also removes an errant semicolon at the bottom of the page.

See fixed version here:

https://mailing-dynamic-demo-jjedoenga-sofn.vercel.app/previews/AccountCreated/accountCreated
https://mailing-dynamic-demo-jjedoenga-sofn.vercel.app/intercepts/mock