### PR TITLE
Empty preview crash

### DIFF
--- a/.changeset/fluffy-walls-brake.md
+++ b/.changeset/fluffy-walls-brake.md
@@ -1,0 +1,6 @@
+---
+"mailing": patch
+"mailing-core": patch
+---
+
+bugfix for crash when adding blank preview file

--- a/packages/cli/src/commands/preview/server/livereload.ts
+++ b/packages/cli/src/commands/preview/server/livereload.ts
@@ -18,6 +18,7 @@ let vectorClock = Date.now();
 
 function renderClock(res: ServerResponse) {
   debug("livereload render clock", vectorClock);
+  res.setHeader("Content-Type", "application/json");
   res.writeHead(200);
   res.end(JSON.stringify({ vectorClock }));
 }
@@ -52,8 +53,6 @@ export function pollShouldReload(
   req: IncomingMessage,
   res: ServerResponse
 ): void {
-  res.setHeader("Content-Type", "application/json");
-
   const clientVectorClock: number = requireParam("vectorClock", req, res);
   if (403 === res.statusCode) return;
 

--- a/packages/cli/src/components/hooks/useLiveReload.tsx
+++ b/packages/cli/src/components/hooks/useLiveReload.tsx
@@ -24,7 +24,7 @@ export default function useLiveReload(onShouldReload: () => void) {
       } catch (e: any) {
         if (!/AbortError/.test(e?.message)) return;
       }
-      if (!shouldReload) return;
+      if (shouldReload?.status !== 200) return;
       const json = await shouldReload.json();
       if (json["vectorClock"] > vectorClock.current) {
         vectorClock.current = json["vectorClock"];

--- a/packages/cli/src/util/__test__/moduleManifestUtil.test.ts
+++ b/packages/cli/src/util/__test__/moduleManifestUtil.test.ts
@@ -1,0 +1,39 @@
+jest.mock("../../moduleManifest");
+
+import moduleManifest from "../../moduleManifest";
+import { previewTree } from "../moduleManifestUtil";
+
+describe("moduleManifestUtil", () => {
+  const ogPreviews = moduleManifest.previews;
+
+  afterEach(() => {
+    moduleManifest.previews = ogPreviews;
+  });
+
+  it("the original module manifest has a tree of preview components", () => {
+    const previews = previewTree();
+    expect(previews).toEqual([
+      ["AccountCreated", ["accountCreated"]],
+      ["NewSignIn", ["newSignIn"]],
+      [
+        "Reservation",
+        ["reservationWithError", "reservationConfirmed", "reservationChanged"],
+      ],
+      ["ResetPassword", ["resetPassword"]],
+    ]);
+  });
+
+  it("does not error on empty preview files", () => {
+    moduleManifest.previews = { AccountCreated: {} } as any;
+    expect(previewTree()[0]).toEqual(["AccountCreated", []]);
+
+    moduleManifest.previews = { AccountCreated: false } as any;
+    expect(previewTree()[0]).toEqual(["AccountCreated", []]);
+
+    moduleManifest.previews = { AccountCreated: { default: jest.fn() } } as any;
+    expect(previewTree()[0]).toEqual(["AccountCreated", []]);
+
+    moduleManifest.previews = { AccountCreated: { __esModule: true } } as any;
+    expect(previewTree()[0]).toEqual(["AccountCreated", []]);
+  });
+});

--- a/packages/cli/src/util/moduleManifestUtil.ts
+++ b/packages/cli/src/util/moduleManifestUtil.ts
@@ -2,9 +2,13 @@ import { JSXElementConstructor, ReactElement } from "react";
 import { previews, config } from "../moduleManifest";
 
 export function previewTree(): [string, string[]][] {
-  return Object.keys(previews).map((previewName: string) => {
-    const m = previews[previewName as keyof typeof previews];
-    return [previewName, Object.keys(m)];
+  return Object.entries(previews).map(([name, preview]) => {
+    return [
+      name,
+      typeof preview === "object"
+        ? Object.keys(preview).filter((k) => k !== "default")
+        : [],
+    ];
   });
 }
 
@@ -21,7 +25,10 @@ export function getPreviewComponent(
         [key: string]: () => ReactElement | undefined;
       }
     | undefined = previews[name as keyof typeof previews] as any;
-  return previewModule?.[functionName]?.();
+  const previewComponent = previewModule?.[functionName];
+  return typeof previewComponent === "function"
+    ? previewComponent()
+    : undefined;
 }
 
 export function getConfig(): MailingConfig {

--- a/packages/cli/src/util/moduleManifestUtil.ts
+++ b/packages/cli/src/util/moduleManifestUtil.ts
@@ -1,25 +1,28 @@
 import { JSXElementConstructor, ReactElement } from "react";
-import { previews, config } from "../moduleManifest";
+import moduleManifest from "../moduleManifest";
 
 export function previewTree(): [string, string[]][] {
-  return Object.entries(previews).map(([name, preview]) => {
+  return Object.entries(moduleManifest.previews).map(([name, preview]) => {
     return [
       name,
       typeof preview === "object"
-        ? Object.keys(preview).filter((k) => k !== "default")
+        ? Object.keys(preview).filter(
+            (k) => k !== "default" && k !== "__esModule"
+          )
         : [],
     ];
   });
 }
 
 export function getPreviewModule(name: string) {
-  return previews[name as keyof typeof previews];
+  return moduleManifest.previews[name as keyof typeof moduleManifest.previews];
 }
 
 export function getPreviewComponent(
   name: string,
   functionName: string
 ): ReactElement<any, string | JSXElementConstructor<any>> | undefined {
+  const { previews } = moduleManifest;
   const previewModule:
     | {
         [key: string]: () => ReactElement | undefined;
@@ -32,5 +35,5 @@ export function getPreviewComponent(
 }
 
 export function getConfig(): MailingConfig {
-  return config;
+  return moduleManifest.config;
 }

--- a/packages/cli/src/util/moduleManifestUtil.ts
+++ b/packages/cli/src/util/moduleManifestUtil.ts
@@ -1,5 +1,5 @@
 import { JSXElementConstructor, ReactElement } from "react";
-import moduleManifest from "../moduleManifest";
+import moduleManifest, { config } from "../moduleManifest";
 
 export function previewTree(): [string, string[]][] {
   return Object.entries(moduleManifest.previews).map(([name, preview]) => {
@@ -35,5 +35,5 @@ export function getPreviewComponent(
 }
 
 export function getConfig(): MailingConfig {
-  return moduleManifest.config;
+  return config;
 }


### PR DESCRIPTION
## Describe your changes

The main fix here is having moduleManifestUtil#previewTree be more careful to reject previewFunctions that do not look like previewFunctions.

I tested in sofn-xyz/mailing-fynn with yalc then mailing@next. Now if you add a blank preview file, it will appear in the compact view without previewFunctions like "Jello" below.

<img width="278" alt="Screenshot 2022-10-31 at 8 51 59 AM" src="https://user-images.githubusercontent.com/282016/199051165-36b6d4e6-46b0-4e78-8036-dfab4db7cfb8.png">


## Issue link

fixes #294 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
