### PR TITLE
make export-previews fail on lint errors

### DIFF
--- a/.changeset/slow-olives-jump.md
+++ b/.changeset/slow-olives-jump.md
@@ -1,0 +1,6 @@
+---
+"mailing": patch
+"mailing-core": patch
+---
+
+export-previews lints, halts on error unless no-lint is passed

--- a/e2e/mailing_tests/jest/__snapshots__/exportPreviews.test.js.snap
+++ b/e2e/mailing_tests/jest/__snapshots__/exportPreviews.test.js.snap
@@ -5,8 +5,8 @@ exports[`exportPreviews command cli --minify runs on templates 1`] = `
 mailing ./previews_html/
 mailing   |-- account_created_account_created.html
 mailing   |-- new_sign_in_new_sign_in.html
-mailing   |-- reservation_reservation_confirmed.html
 mailing   |-- reservation_reservation_changed.html
+mailing   |-- reservation_reservation_confirmed.html
 mailing   |-- reservation_reservation_with_error.html
 mailing   |-- reset_password_reset_password.html
 mailing ✅ Processed 6 previews
@@ -14,13 +14,15 @@ mailing ✅ Processed 6 previews
 "
 `;
 
+exports[`exportPreviews command cli halts on lint errors runs on templates 1`] = `""`;
+
 exports[`exportPreviews command cli runs on templates 1`] = `
 "mailing Exporting preview html to
 mailing ./previews_html/
 mailing   |-- account_created_account_created.html
 mailing   |-- new_sign_in_new_sign_in.html
-mailing   |-- reservation_reservation_confirmed.html
 mailing   |-- reservation_reservation_changed.html
+mailing   |-- reservation_reservation_confirmed.html
 mailing   |-- reservation_reservation_with_error.html
 mailing   |-- reset_password_reset_password.html
 mailing ✅ Processed 6 previews

--- a/e2e/mailing_tests/jest/__snapshots__/exportPreviews.test.js.snap
+++ b/e2e/mailing_tests/jest/__snapshots__/exportPreviews.test.js.snap
@@ -2,26 +2,28 @@
 
 exports[`exportPreviews command cli --minify runs on templates 1`] = `
 "mailing Exporting minified preview html to
-mailing ./previews_html
+mailing ./previews_html/
 mailing   |-- account_created_account_created.html
 mailing   |-- new_sign_in_new_sign_in.html
-mailing   |-- reservation_reservation_with_error.html
 mailing   |-- reservation_reservation_confirmed.html
 mailing   |-- reservation_reservation_changed.html
+mailing   |-- reservation_reservation_with_error.html
 mailing   |-- reset_password_reset_password.html
 mailing ✅ Processed 6 previews
+
 "
 `;
 
 exports[`exportPreviews command cli runs on templates 1`] = `
 "mailing Exporting preview html to
-mailing ./previews_html
+mailing ./previews_html/
 mailing   |-- account_created_account_created.html
 mailing   |-- new_sign_in_new_sign_in.html
-mailing   |-- reservation_reservation_with_error.html
 mailing   |-- reservation_reservation_confirmed.html
 mailing   |-- reservation_reservation_changed.html
+mailing   |-- reservation_reservation_with_error.html
 mailing   |-- reset_password_reset_password.html
 mailing ✅ Processed 6 previews
+
 "
 `;

--- a/e2e/mailing_tests/jest/exportPreviews.test.js
+++ b/e2e/mailing_tests/jest/exportPreviews.test.js
@@ -3,14 +3,21 @@ import execCli from "./util/execCli";
 describe("exportPreviews command", () => {
   describe("cli", () => {
     it("runs on templates", async () => {
-      const out = await execCli("export-previews");
+      const out = await execCli("export-previews --skip-lint");
       expect(out).toMatchSnapshot();
     });
   });
 
   describe("cli --minify", () => {
     it("runs on templates", async () => {
-      const out = await execCli("export-previews --minify");
+      const out = await execCli("export-previews --minify --skip-lint");
+      expect(out).toMatchSnapshot();
+    });
+  });
+
+  describe("cli halts on lint errors", () => {
+    it("runs on templates", async () => {
+      const out = await execCli("export-previews");
       expect(out).toMatchSnapshot();
     });
   });

--- a/packages/cli/src/commands/__test__/__snapshots__/exportPreviews.test.ts.snap
+++ b/packages/cli/src/commands/__test__/__snapshots__/exportPreviews.test.ts.snap
@@ -2,20 +2,23 @@
 
 exports[`exportPreviews command cli --minify runs on templates 1`] = `
 "mailing Exporting minified preview html to
-mailing ./previews_html
-mailing   |-- account_created_account_created.html
+mailing ./previews_html/
 mailing   |-- new_sign_in_new_sign_in.html
-mailing   |-- reservation_reservation_with_error.html
+mailing   |-- reset_password_reset_password.html
 mailing   |-- reservation_reservation_confirmed.html
 mailing   |-- reservation_reservation_changed.html
-mailing   |-- reset_password_reset_password.html
+mailing   |-- reservation_reservation_with_error.html
+mailing   |-- account_created_account_created.html
 mailing ✅ Processed 6 previews
+
 "
 `;
 
+exports[`exportPreviews command cli halts on lint errors runs on templates 1`] = `""`;
+
 exports[`exportPreviews command cli runs on templates 1`] = `
 "mailing Exporting preview html to
-mailing ./previews_html
+mailing ./previews_html/
 mailing   |-- account_created_account_created.html
 mailing   |-- new_sign_in_new_sign_in.html
 mailing   |-- reservation_reservation_with_error.html
@@ -23,5 +26,6 @@ mailing   |-- reservation_reservation_confirmed.html
 mailing   |-- reservation_reservation_changed.html
 mailing   |-- reset_password_reset_password.html
 mailing ✅ Processed 6 previews
+
 "
 `;

--- a/packages/cli/src/commands/__test__/__snapshots__/exportPreviews.test.ts.snap
+++ b/packages/cli/src/commands/__test__/__snapshots__/exportPreviews.test.ts.snap
@@ -3,12 +3,12 @@
 exports[`exportPreviews command cli --minify runs on templates 1`] = `
 "mailing Exporting minified preview html to
 mailing ./previews_html/
-mailing   |-- new_sign_in_new_sign_in.html
-mailing   |-- reset_password_reset_password.html
-mailing   |-- reservation_reservation_confirmed.html
-mailing   |-- reservation_reservation_changed.html
-mailing   |-- reservation_reservation_with_error.html
 mailing   |-- account_created_account_created.html
+mailing   |-- new_sign_in_new_sign_in.html
+mailing   |-- reservation_reservation_changed.html
+mailing   |-- reservation_reservation_confirmed.html
+mailing   |-- reservation_reservation_with_error.html
+mailing   |-- reset_password_reset_password.html
 mailing ✅ Processed 6 previews
 
 "
@@ -21,9 +21,9 @@ exports[`exportPreviews command cli runs on templates 1`] = `
 mailing ./previews_html/
 mailing   |-- account_created_account_created.html
 mailing   |-- new_sign_in_new_sign_in.html
-mailing   |-- reservation_reservation_with_error.html
-mailing   |-- reservation_reservation_confirmed.html
 mailing   |-- reservation_reservation_changed.html
+mailing   |-- reservation_reservation_confirmed.html
+mailing   |-- reservation_reservation_with_error.html
 mailing   |-- reset_password_reset_password.html
 mailing ✅ Processed 6 previews
 

--- a/packages/cli/src/commands/__test__/exportPreviews.test.ts
+++ b/packages/cli/src/commands/__test__/exportPreviews.test.ts
@@ -10,10 +10,11 @@ describe("exportPreviews command", () => {
     await handler({
       outDir: "./out",
       emailsDir: "packages/cli/src/emails",
+      skipLint: true,
     } as ExportPreviewsArgs);
     expect(error).not.toHaveBeenCalled();
     expect(log).toHaveBeenCalledWith("Exporting preview html to");
-    expect(log).toHaveBeenCalledWith("✅ Processed 6 previews");
+    expect(log).toHaveBeenCalledWith("✅ Processed 6 previews\n");
   });
 
   it("errors without emails dir", async () => {
@@ -23,6 +24,7 @@ describe("exportPreviews command", () => {
     await handler({
       outDir: "./out",
       emailsDir: "./NoTaDiReCtOrY",
+      skipLint: true,
     } as ExportPreviewsArgs);
     expect(error).toHaveBeenCalledWith(
       "Could not find emails directory. Have you initialized the project with `mailing init`?"
@@ -31,14 +33,21 @@ describe("exportPreviews command", () => {
 
   describe("cli", () => {
     it("runs on templates", async () => {
-      const out = await execCli("export-previews");
+      const out = await execCli("export-previews --skip-lint");
       expect(out).toMatchSnapshot();
     });
   });
 
   describe("cli --minify", () => {
     it("runs on templates", async () => {
-      const out = await execCli("export-previews --minify");
+      const out = await execCli("export-previews --minify --skip-lint");
+      expect(out).toMatchSnapshot();
+    });
+  });
+
+  describe("cli halts on lint errors", () => {
+    it("runs on templates", async () => {
+      const out = await execCli("export-previews");
       expect(out).toMatchSnapshot();
     });
   });

--- a/packages/cli/src/generator_templates/js/emails/previews/Reservation.jsx
+++ b/packages/cli/src/generator_templates/js/emails/previews/Reservation.jsx
@@ -17,7 +17,8 @@ export function reservationWithError() {
       body={
         <>
           If this was a mistake or if you changed your mind, you can use the
-          link below to rebook your reservation. <a href="#">Learn more</a>
+          link below to rebook your reservation.{" "}
+          <a href="/learn-more">Learn more</a>
         </>
       }
       ctaText={"Rebook Now"}

--- a/packages/cli/src/generator_templates/ts/emails/previews/Reservation.tsx
+++ b/packages/cli/src/generator_templates/ts/emails/previews/Reservation.tsx
@@ -17,7 +17,8 @@ export function reservationWithError() {
       body={
         <>
           If this was a mistake or if you changed your mind, you can use the
-          link below to rebook your reservation. <a href="#">Learn more</a>
+          link below to rebook your reservation.{" "}
+          <a href="/learn-more">Learn more</a>
         </>
       }
       ctaText={"Rebook Now"}


### PR DESCRIPTION
## Describe your changes

- make export previews fail on lint errors unless `--skip-lint` is passed
- all previews are processed before reporting errors
- files written log in lexicographic order
- more whitespace

<img width="657" alt="Screenshot 2022-11-01 at 10 20 08 AM" src="https://user-images.githubusercontent.com/282016/199296245-71f46c19-a4ef-40ae-9daf-91f06e26ad7d.png">

<img width="656" alt="Screenshot 2022-11-01 at 10 20 34 AM" src="https://user-images.githubusercontent.com/282016/199296338-d89a614e-11c7-409f-a0e0-49ca33bcb067.png">

## Issue link

#298 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
