### PR TITLE
Intercept force deliver bugfix

### DIFF
--- a/.changeset/grumpy-crabs-itch.md
+++ b/.changeset/grumpy-crabs-itch.md
@@ -1,0 +1,7 @@
+---
+"mailing": patch
+"mailing-core": patch
+"web": patch
+---
+
+bugfix for force delivery from intercepts #316

--- a/.changeset/slimy-students-melt.md
+++ b/.changeset/slimy-students-melt.md
@@ -1,7 +1,0 @@
----
-"mailing": patch
-"web": patch
-"mailing-core": patch
----
-
-fix next 13 errors

--- a/.changeset/stale-teachers-begin.md
+++ b/.changeset/stale-teachers-begin.md
@@ -1,6 +1,0 @@
----
-"mailing": patch
-"mailing-core": patch
----
-
-remove unused images, fix test file ignores

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,15 @@
 # mailing
 
+## 0.8.14
+
+### Patch Changes
+
+- 22834e4: fix next 13 errors
+- e7627ac: remove unused images, fix test file ignores
+- Updated dependencies [22834e4]
+- Updated dependencies [e7627ac]
+  - mailing-core@0.8.14
+
 ## 0.8.13
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -97,8 +97,8 @@
   },
   "scripts": {
     "dev": "rm -rf .mailing && yarn prisma migrate dev && src/dev.js",
-    "ci:server": "NODE_ENV=test rm -rf .mailing && yarn prisma generate && yarn prisma migrate deploy && src/dev.js > test.log",
-    "ci:server:nohup": "rm -rf .mailing && nohup src/dev.js --quiet > /dev/null 2>&1 &"
+    "ci:server": "rm -rf .mailing && yarn prisma generate && yarn prisma migrate deploy && NODE_ENV=test src/dev.js > test.log",
+    "ci:server:nohup": "rm -rf .mailing && NODE_ENV=test nohup src/dev.js --quiet > /dev/null 2>&1 &"
   },
   "keywords": [
     "email",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mailing",
-  "version": "0.8.13",
+  "version": "0.8.14",
   "main": "dist/mailing.cjs.js",
   "license": "MIT",
   "homepage": "https://github.com/sofn-xyz/mailing#readme",
@@ -76,7 +76,7 @@
     "html-minifier-terser": "^7.0.0",
     "iron-session": "^6.2.1",
     "lodash": "^4.17.21",
-    "mailing-core": "^0.8.13",
+    "mailing-core": "^0.8.14",
     "mjml": "^4.12.0",
     "mjml-react": "^2.0.7",
     "node-fetch": "^2.6.7",

--- a/packages/cli/src/commands/preview/server/start.ts
+++ b/packages/cli/src/commands/preview/server/start.ts
@@ -10,7 +10,6 @@ import { getPreviewsDirectory } from "../../../util/paths";
 import { error, log, debug } from "../../../util/log";
 import {
   createIntercept,
-  sendIntercept,
   showIntercept,
 } from "../../../preview/controllers/intercepts";
 import registerRequireHooks from "../../util/registerRequireHooks";
@@ -110,10 +109,6 @@ export default async function startPreviewServer() {
           createIntercept(req, res);
         } else if (/^\/intercepts\/[a-zA-Z0-9]+\.json/.test(req.url)) {
           showIntercept(req, res);
-        } else if (
-          /^\/intercepts\/[a-zA-Z0-9]+\/forceDeliver.json/.test(req.url)
-        ) {
-          await sendIntercept(req, res);
         } else if (/^\/_+next/.test(req.url)) {
           noLog = true;
           await app.render(req, res, `${pathname}`, query);

--- a/packages/cli/src/commands/preview/server/start.ts
+++ b/packages/cli/src/commands/preview/server/start.ts
@@ -43,6 +43,8 @@ export default async function startPreviewServer() {
 
   const hostname = "localhost";
 
+  process.env.NEXT_PUBLIC_MAILING_SKIP_AUTH =
+    process.env.NODE_ENV === "development" ? "true" : "";
   const app = next({
     dev: true, // true will use the app from source, not built .next bundle
     hostname,

--- a/packages/cli/src/components/Intercept.tsx
+++ b/packages/cli/src/components/Intercept.tsx
@@ -22,7 +22,7 @@ const Intercept: React.FC<InterceptProps> = ({ data }) => {
 
   const handleForceDeliver = useCallback(async () => {
     if (!data) return;
-    const { to, cc, bcc } = data;
+    const { to, cc, bcc, html, subject } = data;
 
     const numRecipients =
       recipientCount(to) + recipientCount(cc) + recipientCount(bcc);
@@ -32,9 +32,17 @@ const Intercept: React.FC<InterceptProps> = ({ data }) => {
     );
     if (!confirmed) return;
 
-    const res = await fetch(`/intercepts/${data.id}/forceDeliver.json`, {
+    const res = await fetch(`/api/sendMail`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        to,
+        cc,
+        bcc,
+        html,
+        subject,
+        dangerouslyForceDeliver: true,
+      }),
     });
     if (res.status !== 200) {
       alert(

--- a/packages/cli/src/pages/api/previews/send.ts
+++ b/packages/cli/src/pages/api/previews/send.ts
@@ -3,7 +3,7 @@ import { error } from "../../../util/log";
 import { sendMail } from "../../../moduleManifest";
 import { getPreviewComponent } from "../../../util/moduleManifestUtil";
 
-export default async function showPreviewsIndex(
+export default async function send(
   req: NextApiRequest,
   res: NextApiResponse<SendPreviewResponseBody>
 ) {
@@ -14,22 +14,20 @@ export default async function showPreviewsIndex(
   }
   const body: SendPreviewRequestBody = req.body;
 
-  // Caller can provide html or preview references, html takes precedence.
-  const { html, to, subject, previewClass, previewFunction } = body;
+  const { to, subject, previewClass, previewFunction } = body;
   let component;
-  if (!html && previewClass && previewFunction) {
+  if (previewClass && previewFunction) {
     component = getPreviewComponent(previewClass, previewFunction);
   }
 
-  if (!html && !component) {
-    error("no html provided, no component found");
+  if (!component) {
+    error("no component found");
     res.writeHead(400);
     res.end(JSON.stringify({ error: "no html provided, no component found" }));
     return;
   }
 
   await sendMail({
-    html,
     component,
     to,
     dangerouslyForceDeliver: true,

--- a/packages/cli/src/preview/controllers/intercepts.tsx
+++ b/packages/cli/src/preview/controllers/intercepts.tsx
@@ -1,7 +1,6 @@
 import { IncomingMessage, ServerResponse } from "http";
 import { log } from "../../util/log";
 import { renderNotFound } from "./application";
-import { sendMail } from "../../moduleManifest";
 
 const cache: {
   [id: string]: Intercept;
@@ -42,23 +41,6 @@ export function showIntercept(req: IncomingMessage, res: ServerResponse) {
     res.writeHead(200);
     const intercept: Intercept = { ...data };
     res.end(JSON.stringify(intercept));
-  } else {
-    renderNotFound(res);
-  }
-}
-
-export async function sendIntercept(req: IncomingMessage, res: ServerResponse) {
-  const parts = req.url?.split("/");
-  const id = parts ? parts[parts.length - 2] : "";
-  const data = cache[id];
-
-  if (data) {
-    // force deliver, we don't want this one intercepted
-    await sendMail({ ...data, dangerouslyForceDeliver: true });
-
-    res.setHeader("Content-Type", "application/json");
-    res.writeHead(200);
-    res.end();
   } else {
     renderNotFound(res);
   }

--- a/packages/cli/src/util/__test__/validateApiKey.test.ts
+++ b/packages/cli/src/util/__test__/validateApiKey.test.ts
@@ -1,0 +1,56 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { validateApiKey } from "../validateApiKey";
+import prisma from "../../../prisma";
+
+function mockRequestResponse() {
+  const { req, res } = {
+    req: {} as NextApiRequest,
+    res: {} as unknown as NextApiResponse,
+  };
+  res.json = jest.fn();
+  res.end = jest.fn();
+  res.status = jest.fn(() => res);
+  req.headers = { "Content-Type": "application/json" };
+  req.query = {};
+  return { req, res };
+}
+
+describe("validateApiKey", () => {
+  const OG_NODE_ENV = process.env.NODE_ENV;
+  afterEach(() => {
+    (process.env as any).NODE_ENV = OG_NODE_ENV;
+  });
+
+  it("returns true if NODE_ENV is development", async () => {
+    (process.env as any).NODE_ENV = "development";
+    const { req, res } = mockRequestResponse();
+    const result = await validateApiKey(req, res);
+    expect(result).toBe(true);
+  });
+
+  it("returns false if NODE_ENV is not development and apiKey is not a string", async () => {
+    const { req, res } = mockRequestResponse();
+    const result = await validateApiKey(req, res);
+    expect(result).toBe(false);
+  });
+
+  it("returns false if NODE_ENV is not development and apiKey is not valid", async () => {
+    const { req, res } = mockRequestResponse();
+    jest
+      .spyOn(prisma.apiKey, "findFirstOrThrow")
+      .mockRejectedValueOnce(new Error("NOT FOUND"));
+    req.query = { apiKey: "321" };
+    const result = await validateApiKey(req, res);
+    expect(result).toBe(false);
+  });
+
+  it("returns true if NODE_ENV is not development and apiKey is valid", async () => {
+    const { req, res } = mockRequestResponse();
+    jest
+      .spyOn(prisma.apiKey, "findFirstOrThrow")
+      .mockReturnValueOnce(Promise.resolve({ id: "123" }) as any);
+    req.query = { apiKey: "123" };
+    const result = await validateApiKey(req, res);
+    expect(result).toBe(true);
+  });
+});

--- a/packages/cli/src/util/__test__/validateApiKey.test.ts
+++ b/packages/cli/src/util/__test__/validateApiKey.test.ts
@@ -16,13 +16,12 @@ function mockRequestResponse() {
 }
 
 describe("validateApiKey", () => {
-  const OG_NODE_ENV = process.env.NODE_ENV;
   afterEach(() => {
-    (process.env as any).NODE_ENV = OG_NODE_ENV;
+    delete (process.env as any).NEXT_PUBLIC_MAILING_SKIP_AUTH;
   });
 
   it("returns true if NODE_ENV is development", async () => {
-    (process.env as any).NODE_ENV = "development";
+    (process.env as any).NEXT_PUBLIC_MAILING_SKIP_AUTH = "true";
     const { req, res } = mockRequestResponse();
     const result = await validateApiKey(req, res);
     expect(result).toBe(true);

--- a/packages/cli/src/util/validateApiKey.ts
+++ b/packages/cli/src/util/validateApiKey.ts
@@ -5,6 +5,8 @@ export async function validateApiKey(
   req: NextApiRequest,
   res: NextApiResponse
 ): Promise<boolean> {
+  if (process.env.NODE_ENV === "development") return true;
+
   const apiKey = (req.headers && req.headers["x-api-key"]) || req.query.apiKey;
   if (typeof apiKey !== "string") {
     res.status(422).end("expected x-api-key in header or apiKey in query");

--- a/packages/cli/src/util/validateApiKey.ts
+++ b/packages/cli/src/util/validateApiKey.ts
@@ -5,7 +5,7 @@ export async function validateApiKey(
   req: NextApiRequest,
   res: NextApiResponse
 ): Promise<boolean> {
-  if (process.env.NODE_ENV === "development") return true;
+  if (process.env.NEXT_PUBLIC_MAILING_SKIP_AUTH) return true;
 
   const apiKey = (req.headers && req.headers["x-api-key"]) || req.query.apiKey;
   if (typeof apiKey !== "string") {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # mailing-core
 
+## 0.8.14
+
+### Patch Changes
+
+- 22834e4: fix next 13 errors
+- e7627ac: remove unused images, fix test file ignores
+
 ## 0.8.13
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mailing-core",
-  "version": "0.8.13",
+  "version": "0.8.14",
   "main": "dist/mailing-core.cjs.js",
   "license": "MIT",
   "description": "Fun email development environment (core library only)",

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -1,5 +1,11 @@
 # web
 
+## 0.4.8
+
+### Patch Changes
+
+- 22834e4: fix next 13 errors
+
 ## 0.4.7
 
 ### Patch Changes

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "private": true,
   "scripts": {
     "dev": "yarn prisma migrate dev && next dev",


### PR DESCRIPTION
## Describe your changes

This fixes a bug with the Force Deliver Intercepts feature. It was using the example copy of sendMail bundled by esbuild rather than the user-defined sendMail. I fixed by getting rid of the intercept deliver route and instead using /api/sendMail. I think this is a better design because it gets rid of a codepath.

I added a unit test for the auth change (api key checks always pass in development so that the localhost preview server can use any api without restriction).

I manually tested with an example next app pointed at mailtrap and it seems to work well.

<img width="555" alt="Screenshot 2022-11-08 at 1 10 36 PM" src="https://user-images.githubusercontent.com/282016/200676090-09b58d4f-8f70-4f93-af6f-d885ed533fc6.png">

<img width="1208" alt="Screenshot 2022-11-08 at 12 55 38 PM" src="https://user-images.githubusercontent.com/282016/200675952-6eac44aa-57d7-40a0-a7f4-267f9241678d.png">

<img width="1760" alt="Screenshot 2022-11-08 at 12 53 24 PM" src="https://user-images.githubusercontent.com/282016/200675957-c6cd2057-a704-4ee1-ab65-b6e711a83ecd.png">

## Issue link

fixes #316 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
