### PR TITLE
Make mobile previewer iphone 8 sized

### DIFF
--- a/packages/cli/src/components/HotIFrame.tsx
+++ b/packages/cli/src/components/HotIFrame.tsx
@@ -53,12 +53,12 @@ const HotIFrame: React.FC<HotIFrameProps> = ({
       <style jsx>{`
         .mobile.frame {
           padding: 64px 16px 74px;
-          max-width: 352px;
           border-radius: 32px;
-          max-height: 706px;
+          max-height: 807px;
+          max-width: 409px;
         }
         .mobile iframe {
-          height: 568px;
+          height: 667px;
           max-width: 375px;
           background-color: white;
         }


### PR DESCRIPTION
## Describe your changes
Increases the viewport size of the mobile preview to 375x667, which is more inline with the larger viewport sizes of recent phones. 

## Issue link
N/A

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
