### PR TITLE
remove logger use on client

### DIFF
--- a/packages/cli/src/pages/previews/[[...path]].tsx
+++ b/packages/cli/src/pages/previews/[[...path]].tsx
@@ -10,7 +10,6 @@ import PreviewViewer, {
 } from "../../components/PreviewViewer";
 import { flatten } from "lodash";
 import { render } from "../../util/mjml";
-import { log } from "../../util/log";
 
 type Params = { path: string[] };
 
@@ -44,7 +43,7 @@ export const getStaticProps: GetStaticProps = async (context) => {
   if (previewClass && previewFunction) {
     const component = getPreviewComponent(previewClass, previewFunction);
     if (!component) {
-      log(
+      console.log(
         `${previewClass} or ${previewFunction} not found, redirecting to home`
       );
       return {


### PR DESCRIPTION
## Describe your changes

I think this will error when it's called because the logger requires fs. This is the only instance I can find where it's used on the client.
