### PR TITLE
support for async preview functions

### DIFF
--- a/.changeset/quiet-wolves-add.md
+++ b/.changeset/quiet-wolves-add.md
@@ -1,0 +1,6 @@
+---
+"mailing": patch
+"mailing-core": patch
+---
+
+add support for async preview functions

--- a/packages/cli/src/commands/exportPreviews.ts
+++ b/packages/cli/src/commands/exportPreviews.ts
@@ -107,7 +107,7 @@ export const handler = buildHandler(
             count++;
 
             const { html, errors, htmlLint } = render(
-              previewModule[previewFunction]()
+              await previewModule[previewFunction]()
             );
             if (errors.length) {
               error(`MJML errors rendering ${filename}:`, errors);

--- a/packages/cli/src/generator_templates/js/emails/previews/Reservation.jsx
+++ b/packages/cli/src/generator_templates/js/emails/previews/Reservation.jsx
@@ -1,7 +1,7 @@
 import Reservation from "../Reservation";
 import BulletedList from "../components/BulletedList";
 
-export function reservationWithError() {
+export async function reservationWithError() {
   return (
     <Reservation
       headline="Reservation Canceled"

--- a/packages/cli/src/generator_templates/ts/emails/previews/Reservation.tsx
+++ b/packages/cli/src/generator_templates/ts/emails/previews/Reservation.tsx
@@ -1,7 +1,7 @@
 import Reservation from "../Reservation";
 import BulletedList from "../components/BulletedList";
 
-export function reservationWithError() {
+export async function reservationWithError() {
   return (
     <Reservation
       headline="Reservation Canceled"

--- a/packages/cli/src/pages/api/previews/[previewClass]/[previewFunction].ts
+++ b/packages/cli/src/pages/api/previews/[previewClass]/[previewFunction].ts
@@ -3,7 +3,7 @@ import { error } from "../../../../util/log";
 import { render } from "../../../../util/mjml";
 import { getPreviewComponent } from "../../../../util/moduleManifestUtil";
 
-export default function showPreview(
+export default async function showPreview(
   req: NextApiRequest,
   res: NextApiResponse<ShowPreviewResponseBody>
 ) {
@@ -17,7 +17,10 @@ export default function showPreview(
   }
 
   const cleanpreviewFunction = previewFunction.replace(/\.json$/, "");
-  const component = getPreviewComponent(previewClass, cleanpreviewFunction);
+  const component = await getPreviewComponent(
+    previewClass,
+    cleanpreviewFunction
+  );
 
   if (component?.props) {
     try {

--- a/packages/cli/src/pages/api/previews/index.ts
+++ b/packages/cli/src/pages/api/previews/index.ts
@@ -1,4 +1,3 @@
-import { flatten } from "lodash";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { parse } from "node-html-parser";
 import { render } from "../../../util/mjml";
@@ -17,13 +16,13 @@ export type PreviewIndexResponseBody = {
 
 const MAX_TEXT_CHARS = 140;
 
-function getPreviewFunction(
+async function getPreviewFunction(
   previewClass: string,
   name: string
-): [string, string] {
+): Promise<[string, string]> {
   let text = "";
   try {
-    const component = getPreviewComponent(previewClass, name);
+    const component = await getPreviewComponent(previewClass, name);
     if (!component) throw new Error(`${previewClass}#${name} not found`);
     const { html } = render(component);
     // slice out the body to minimize funky head parsing
@@ -44,8 +43,8 @@ export default async function showPreviewsIndex(
 ) {
   const previews = previewTree();
   const previewText = Object.fromEntries(
-    flatten(
-      previews.map((previewGroup) =>
+    await Promise.all(
+      previews.flatMap((previewGroup) =>
         previewGroup[1].map((pf) => getPreviewFunction(previewGroup[0], pf))
       )
     )

--- a/packages/cli/src/pages/api/previews/send.ts
+++ b/packages/cli/src/pages/api/previews/send.ts
@@ -17,7 +17,7 @@ export default async function send(
   const { to, subject, previewClass, previewFunction } = body;
   let component;
   if (previewClass && previewFunction) {
-    component = getPreviewComponent(previewClass, previewFunction);
+    component = await getPreviewComponent(previewClass, previewFunction);
   }
 
   if (!component) {

--- a/packages/cli/src/pages/previews/[[...path]].tsx
+++ b/packages/cli/src/pages/previews/[[...path]].tsx
@@ -41,7 +41,7 @@ export const getStaticProps: GetStaticProps = async (context) => {
   const [previewClass, previewFunction] = path || [];
   let preview = null;
   if (previewClass && previewFunction) {
-    const component = getPreviewComponent(previewClass, previewFunction);
+    const component = await getPreviewComponent(previewClass, previewFunction);
     if (!component) {
       console.log(
         `${previewClass} or ${previewFunction} not found, redirecting to home`

--- a/packages/cli/src/util/moduleManifestUtil.ts
+++ b/packages/cli/src/util/moduleManifestUtil.ts
@@ -18,10 +18,10 @@ export function getPreviewModule(name: string) {
   return moduleManifest.previews[name as keyof typeof moduleManifest.previews];
 }
 
-export function getPreviewComponent(
+export async function getPreviewComponent(
   name: string,
   functionName: string
-): ReactElement<any, string | JSXElementConstructor<any>> | undefined {
+): Promise<ReactElement<any, string | JSXElementConstructor<any>> | undefined> {
   const { previews } = moduleManifest;
   const previewModule:
     | {
@@ -30,7 +30,7 @@ export function getPreviewComponent(
     | undefined = previews[name as keyof typeof previews] as any;
   const previewComponent = previewModule?.[functionName];
   return typeof previewComponent === "function"
-    ? previewComponent()
+    ? await previewComponent()
     : undefined;
 }
 


### PR DESCRIPTION
## Describe your changes

I think it's just this easy. This adds support for making preview functions async so that you can do data fetching inside of them. This is completely optional functionality so I'm going to push off documenting for the forthcoming docs site.

I added a single async preview to ts and js templates because we have decent test coverage for compilation errors of those.

## Issue link

#331 
#276

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
