### PR TITLE
e2e test fixes/improvements

### DIFF
--- a/e2e/app.rb
+++ b/e2e/app.rb
@@ -10,6 +10,9 @@ require_relative 'app/remix_ts'
 require_relative 'app/remix_js'
 
 module App
+  # does this framework use typescript? if so, e2e tests will perform typescript specific checks
+  attr_reader :typescript
+
   CONFIGS = {
     standalone: App::Standalone,
     turbo: App::Turbo,
@@ -20,6 +23,8 @@ module App
     remix_ts: App::RemixTs,
     remix_js: App::RemixJs
   }.freeze
+
+  SKIPPED_APPS = %i[turbo].freeze
 
   def self.from_name(app_name)
     CONFIGS[app_name.to_sym]

--- a/e2e/app/next_js.rb
+++ b/e2e/app/next_js.rb
@@ -12,7 +12,7 @@ module App
 
     def yarn_create!
       Dir.chdir(root_dir) do
-        system_quiet('yarn create next-app .')
+        system_quiet('yarn create next-app . --javascript --no-eslint')
       end
     end
   end

--- a/e2e/app/next_ts.rb
+++ b/e2e/app/next_ts.rb
@@ -5,6 +5,7 @@ require_relative 'base'
 module App
   class NextTs < Base
     def initialize(root_dir, *args)
+      @typescript = true
       super('next_ts', root_dir, *args)
     end
 
@@ -12,7 +13,7 @@ module App
 
     def yarn_create!
       Dir.chdir(root_dir) do
-        system_quiet('yarn create next-app . --typescript')
+        system_quiet('yarn create next-app . --typescript --no-eslint')
       end
     end
   end

--- a/e2e/app/redwood_ts.rb
+++ b/e2e/app/redwood_ts.rb
@@ -5,6 +5,7 @@ require_relative 'base'
 module App
   class RedwoodTs < Base
     def initialize(root_dir, *args)
+      @typescript = true
       super('redwood_ts', root_dir, *args)
     end
 

--- a/e2e/app/remix_ts.rb
+++ b/e2e/app/remix_ts.rb
@@ -5,6 +5,7 @@ require_relative 'base'
 module App
   class RemixTs < Base
     def initialize(root_dir, *args)
+      @typescript = true
       super('remix_ts', root_dir, *args)
     end
 

--- a/e2e/cli.rb
+++ b/e2e/cli.rb
@@ -5,6 +5,7 @@ require_relative 'helpers/system_utils'
 require_relative 'commands/run'
 require_relative 'commands/setup'
 require_relative 'commands/run_all'
+require_relative 'commands/update_snapshot'
 require_relative 'app'
 
 class Cli
@@ -14,7 +15,9 @@ class Cli
   def initialize
     assign_opts!
 
-    if opt?('setup')
+    if opt?('update-snapshot')
+      Commands::UpdateSnapshot.perform(opts: @opts)
+    elsif opt?('setup')
       raise 'Missing required option: --app' unless opt?('app')
 
       Commands::Setup.perform(app_name: opt('app'), opts: @opts)
@@ -33,10 +36,13 @@ class Cli
       puts '    run [flags] - run tests for a given app'
       puts '    setup [flags] - build a given app'
       puts '    run-all [flags] - run tests for all apps'
+      puts '    update-snapshot [flags] - update jest snapshots (uses next_ts unless --app is specified)'
       puts "\n"
 
       puts '  Flags:'
       puts '    --app [app_name] - name of app to run tests for'
+      puts '    --save-cache - save each framework install (before mailing is added) to the `cache` directory.
+      Subsequent test runs will start with a copy of the cache instead of running `yarn create` and `yarn install`'
       puts '    --help - show this help message'
       puts "\n"
     end

--- a/e2e/commands/run_all.rb
+++ b/e2e/commands/run_all.rb
@@ -4,12 +4,14 @@ require_relative '../mailing'
 
 module Commands
   class RunAll
-    SKIPPED_APPS = %i[redwood_js redwood_ts].freeze
+    def self.supported_frameworks
+      App::CONFIGS.keys - App::SKIPPED_APPS
+    end
 
     def self.perform(opts: {})
       Mailing.build
 
-      (App::CONFIGS.keys - SKIPPED_APPS).each do |app_name|
+      supported_frameworks.each do |app_name|
         Commands::Run.perform(app_name: app_name, opts: opts.merge('skip-build' => true))
       end
     end

--- a/e2e/commands/update_snapshot.rb
+++ b/e2e/commands/update_snapshot.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require_relative '../mailing'
+
+module Commands
+  class UpdateSnapshot
+    include SystemUtils
+
+    def self.perform(opts: {})
+      app_name = opts['app'] || 'next_ts'
+      new(app_name: app_name, opts: opts)
+    end
+
+    # @param [String] app_name
+    def initialize(app_name:, opts: {})
+      verify_mailing_port_is_free!
+      config = Commands::Setup.perform(app_name: app_name, opts: opts)
+      app = config.app
+
+      # Run Jest Tests
+      Dir.chdir(app.install_dir) do
+        announce! "Running jest tests with --updateSnapshot for #{app_name}", '🃏'
+        system('yarn jest --rootDir=mailing_tests/jest --config mailing_tests/jest/jest.config.json --updateSnapshot')
+
+        # copy snapshots back to mailing
+        announce! 'Copying updated snapshots to the mailing project', '🥋'
+        system(format('find ./mailing_tests -name \'*.snap\' | cpio -p %s', Config::E2E_ROOT))
+      end
+    end
+  end
+end


### PR DESCRIPTION
I peeled this off my other branch to make it easier to review, plus it corrects some bugs in main
In this branch:
- align "skipped apps" when running in localhost with what runs in github workflows currently (all frameworks but turbo are supported)
- restore "save-cache" and "use_cache" functionality
- introduce an `update-snapshot` cli command that updates the e2e jest snapshot tests

- next_js behavior: in main, the next apps have the wrong flags for typescript (default flipped in v13), so next_js likely does not install the javascript version of next. additionally, next no requires you to choose eslint or not, otherwise there is a prompt that causes the tests to run very slowly while it waits for the prompt to timeout
- redwood_ts behavior: in main, redwood_ts actually installs the jsx templates because tsconfig.json is not in the root directory so it's not detected as being a typescript by our current naive algo.  see https://github.com/sofn-xyz/mailing/issues/338 for the full fix.  this branch includes a temporary fix (override mailing.config.json with `npx mailing init --typescript=true`) the warning below that is now output when redwood_ts runs:
```
+        * * * * * * * * * * * * * * * * *
+        ⚠️ WARNING ⚠️ Expected mailing.config.json to have 'typescript' set to true but it was not!\n
+        In other words, mailing init did not correctly detect that this is a typescript project\n
+        Please implement https://github.com/sofn-xyz/mailing/issues/338 and then have this raise an error instead or move this check to a jest test\n
+        Until #338 is implemented, the e2e tests will override this by passing the --typescript flag to `npx mailing init` in typescript frameworks.
+        * * * * * * * * * * * * * * * * *
```

