### PR TITLE
add subjects to templates

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -16,7 +16,7 @@ const jsdomConfig = async (): Promise<any> => {
       name: "jest.jsdom",
       color: "magenta",
     },
-    testEnvironment: "jest-environment-jsdom",
+    testEnvironment: "<rootDir>/jsdom.env.ts",
     setupFilesAfterEnv: ["<rootDir>/testSetup.ts"],
     testMatch: [
       "<rootDir>/packages/cli/src/pages/**/__test__/**/*.test.[jt]s?(x)",

--- a/jsdom.env.ts
+++ b/jsdom.env.ts
@@ -1,0 +1,21 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+import { TestEnvironment } from "jest-environment-jsdom";
+
+class CustomTestEnvironment extends TestEnvironment {
+  async setup() {
+    await super.setup();
+    // TextEncoder is required by node-html-parser
+    if (typeof this.global.TextEncoder === "undefined") {
+      const { TextEncoder } = require("util");
+      this.global.TextEncoder = TextEncoder;
+    }
+
+    // setImmediate is required by nodemailer
+    if (typeof this.global.setImmediate === "undefined") {
+      const { setImmediate } = require("timers");
+      this.global.setImmediate = setImmediate;
+    }
+  }
+}
+
+module.exports = CustomTestEnvironment;

--- a/packages/cli/src/components/PreviewSender.tsx
+++ b/packages/cli/src/components/PreviewSender.tsx
@@ -1,13 +1,11 @@
 import React, { useCallback, useEffect, useState } from "react";
 
 type PreviewSenderProps = {
-  html?: string;
-  previewFunction?: string;
-  previewClass?: string;
+  previewFunction: string;
+  previewClass: string;
 };
 
 const PreviewSender: React.FC<PreviewSenderProps> = ({
-  html,
   previewFunction,
   previewClass,
 }) => {
@@ -34,10 +32,8 @@ const PreviewSender: React.FC<PreviewSenderProps> = ({
         setSending(true);
         const payload: SendPreviewRequestBody = {
           to: email,
-          html,
           previewFunction,
           previewClass,
-          subject: `${previewClass} - ${previewFunction}`,
         };
 
         const response = await fetch("/api/previews/send", {
@@ -76,7 +72,7 @@ const PreviewSender: React.FC<PreviewSenderProps> = ({
         setSending(false);
       }
     },
-    [html, previewClass, previewFunction, email]
+    [previewClass, previewFunction, email]
   );
 
   const onInputChange: React.ChangeEventHandler<HTMLInputElement> = useCallback(

--- a/packages/cli/src/custom.d.ts
+++ b/packages/cli/src/custom.d.ts
@@ -43,8 +43,3 @@ type MailingConfig = {
   port?: number;
   quiet?: boolean;
 };
-
-/* eslint-disable-next-line @typescript-eslint/ban-types */
-interface Template<P> extends React.FC<P> {
-  subject?: string | ((args: Partial<P>) => string);
-}

--- a/packages/cli/src/custom.d.ts
+++ b/packages/cli/src/custom.d.ts
@@ -10,10 +10,8 @@ type Intercept = {
 
 type SendPreviewRequestBody = {
   to: string;
-  html?: string;
-  previewFunction?: string;
-  previewClass?: string;
-  subject: string;
+  previewFunction: string;
+  previewClass: string;
 };
 
 type SendPreviewResponseBody = {
@@ -45,3 +43,8 @@ type MailingConfig = {
   port?: number;
   quiet?: boolean;
 };
+
+/* eslint-disable-next-line @typescript-eslint/ban-types */
+interface Template<P> extends React.FC<P> {
+  subject?: string | ((args: Partial<P>) => string);
+}

--- a/packages/cli/src/generator_templates/ts/emails/AccountCreated.tsx
+++ b/packages/cli/src/generator_templates/ts/emails/AccountCreated.tsx
@@ -17,6 +17,7 @@ import {
   textBase,
   textXl,
 } from "./components/theme";
+import { Template } from "mailing-core";
 
 type AccountCreatedProps = { name: string };
 

--- a/packages/cli/src/generator_templates/ts/emails/AccountCreated.tsx
+++ b/packages/cli/src/generator_templates/ts/emails/AccountCreated.tsx
@@ -18,7 +18,9 @@ import {
   textXl,
 } from "./components/theme";
 
-const AccountCreated: React.FC<{ name: string }> = ({ name }) => (
+type AccountCreatedProps = { name: string };
+
+const AccountCreated: Template<AccountCreatedProps> = ({ name }) => (
   <Mjml>
     <Head />
     <MjmlBody width={600}>
@@ -75,5 +77,7 @@ const AccountCreated: React.FC<{ name: string }> = ({ name }) => (
     </MjmlBody>
   </Mjml>
 );
+
+AccountCreated.subject = ({ name }) => `Welcome to BookBook, ${name}!`;
 
 export default AccountCreated;

--- a/packages/cli/src/generator_templates/ts/emails/NewSignIn.tsx
+++ b/packages/cli/src/generator_templates/ts/emails/NewSignIn.tsx
@@ -25,6 +25,7 @@ type NewSignInProps = {
   body: ReactElement;
   bulletedList: ReactElement;
 };
+import { Template } from "mailing-core";
 
 const NewSignIn: Template<NewSignInProps> = ({
   name,

--- a/packages/cli/src/generator_templates/ts/emails/NewSignIn.tsx
+++ b/packages/cli/src/generator_templates/ts/emails/NewSignIn.tsx
@@ -26,7 +26,7 @@ type NewSignInProps = {
   bulletedList: ReactElement;
 };
 
-const NewSignIn: React.FC<NewSignInProps> = ({
+const NewSignIn: Template<NewSignInProps> = ({
   name,
   headline,
   body,

--- a/packages/cli/src/generator_templates/ts/emails/Reservation.tsx
+++ b/packages/cli/src/generator_templates/ts/emails/Reservation.tsx
@@ -27,7 +27,7 @@ type ReservationProps = {
   ctaText?: string;
 };
 
-const Reservation: React.FC<ReservationProps> = ({
+const Reservation: Template<ReservationProps> = ({
   headline,
   body,
   bulletedList,

--- a/packages/cli/src/generator_templates/ts/emails/Reservation.tsx
+++ b/packages/cli/src/generator_templates/ts/emails/Reservation.tsx
@@ -19,6 +19,7 @@ import {
   MjmlSpacer,
   MjmlDivider,
 } from "mjml-react";
+import { Template } from "mailing-core";
 
 type ReservationProps = {
   headline: string;

--- a/packages/cli/src/generator_templates/ts/emails/ResetPassword.tsx
+++ b/packages/cli/src/generator_templates/ts/emails/ResetPassword.tsx
@@ -21,7 +21,7 @@ type ResetPasswordProps = {
   ctaText: string;
 };
 
-const ResetPassword: React.FC<ResetPasswordProps> = ({
+const ResetPassword: Template<ResetPasswordProps> = ({
   name,
   body,
   ctaText,

--- a/packages/cli/src/generator_templates/ts/emails/ResetPassword.tsx
+++ b/packages/cli/src/generator_templates/ts/emails/ResetPassword.tsx
@@ -14,6 +14,7 @@ import {
   MjmlSpacer,
   MjmlDivider,
 } from "mjml-react";
+import { Template } from "mailing-core";
 
 type ResetPasswordProps = {
   name: string;

--- a/packages/cli/src/pages/api/previews/__test__/__snapshots__/index.test.tsx.snap
+++ b/packages/cli/src/pages/api/previews/__test__/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,42 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`index should return previews 1`] = `
+{
+  "previewText": {
+    "/previews/AccountCreated/accountCreated": "Welcome to BookBook, Amelita!",
+    "/previews/NewSignIn/newSignIn": "Security Alert: New Sign-In Hello Amelita, We noticed a new sign-in to your BookBook account on a Mac device. If this was you, you don’t nee",
+    "/previews/Reservation/reservationChanged": "Reservation Changed • Salazar in Silver Lake • Sunday, Aug 22 at 1:30pm • Party of 4, patio You’re all set! Your reservation at Salazar has ",
+    "/previews/Reservation/reservationConfirmed": "Reservation Confirmed • Salazar in Silver Lake • Saturday, Aug 22 at 1:30pm • Party of 4, patio Thanks for booking your reservation at Salaz",
+    "/previews/Reservation/reservationWithError": "Reservation Canceled • Salazar in Silver Lake • Sunday, Aug 22 at 1:30pm • Party of 4, patio If this was a mistake or if you changed your mi",
+    "/previews/ResetPassword/resetPassword": "Hello Amelita, We’ve received your request to change your password. Use the link below to set up a new password for your account. This link ",
+  },
+  "previews": [
+    [
+      "AccountCreated",
+      [
+        "accountCreated",
+      ],
+    ],
+    [
+      "NewSignIn",
+      [
+        "newSignIn",
+      ],
+    ],
+    [
+      "Reservation",
+      [
+        "reservationWithError",
+        "reservationConfirmed",
+        "reservationChanged",
+      ],
+    ],
+    [
+      "ResetPassword",
+      [
+        "resetPassword",
+      ],
+    ],
+  ],
+}
+`;

--- a/packages/cli/src/pages/api/previews/__test__/index.test.tsx
+++ b/packages/cli/src/pages/api/previews/__test__/index.test.tsx
@@ -1,0 +1,37 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { createMocks } from "node-mocks-http";
+import index from "..";
+
+describe("index", () => {
+  it("should return previews", async () => {
+    const { req, res } = createMocks({
+      method: "GET",
+    });
+
+    await index(
+      req as unknown as NextApiRequest,
+      res as unknown as NextApiResponse
+    );
+
+    expect(res.statusCode).toBe(200);
+    const json = res._getJSONData();
+    expect(json).toMatchSnapshot();
+  });
+
+  it("should return template subject if it exists", async () => {
+    const { req, res } = createMocks({
+      method: "GET",
+    });
+
+    await index(
+      req as unknown as NextApiRequest,
+      res as unknown as NextApiResponse
+    );
+
+    expect(res.statusCode).toBe(200);
+    const json = res._getJSONData();
+    expect(json["previewText"]["/previews/AccountCreated/accountCreated"]).toBe(
+      "Welcome to BookBook, Amelita!"
+    );
+  });
+});

--- a/packages/cli/src/pages/api/previews/__test__/send.test.tsx
+++ b/packages/cli/src/pages/api/previews/__test__/send.test.tsx
@@ -12,6 +12,7 @@ jest.mock("../../../../moduleManifest", () => ({
 
 jest.mock("../../../../util/moduleManifestUtil", () => ({
   getPreviewComponent: jest.fn(),
+  getTemplateModule: jest.fn(),
 }));
 
 describe("send", () => {

--- a/packages/cli/src/pages/api/previews/index.ts
+++ b/packages/cli/src/pages/api/previews/index.ts
@@ -23,20 +23,22 @@ async function getPreviewFunction(
 ): Promise<[string, string]> {
   let text = "";
   try {
-    const component = await getTemplateModule(previewClass);
-    if (!component) throw new Error(`${previewClass} not found`);
-
-    const previewComponent = await getPreviewComponent(previewClass, name);
-    if (!previewComponent) throw new Error(`${previewClass}#${name} not found`);
+    const component = await getPreviewComponent(previewClass, name);
+    if (!component) throw new Error(`${previewClass}#${name} not found`);
 
     // Try to build preview text from subject
-    if (typeof component.subject === "function") {
-      text = component.subject(previewComponent.props);
+    const template = getTemplateModule(previewClass);
+    if (template) {
+      if (typeof template.subject === "function") {
+        text = template.subject(component.props);
+      } else if (typeof template.subject === "string") {
+        text = template.subject;
+      }
     }
 
     // If that didn't work, try to build preview text from the rendered preview
     if (text.length === 0) {
-      const { html } = render(previewComponent);
+      const { html } = render(component);
       // slice out the body to minimize funky head parsing
       const body = /<body[^>]*>((.|[\n\r])*)<\/body>/im.exec(html);
       if (body && body[1]) {

--- a/packages/cli/src/pages/api/previews/send.ts
+++ b/packages/cli/src/pages/api/previews/send.ts
@@ -1,7 +1,10 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { error } from "../../../util/log";
 import { sendMail } from "../../../moduleManifest";
-import { getPreviewComponent } from "../../../util/moduleManifestUtil";
+import {
+  getPreviewComponent,
+  getTemplateModule,
+} from "../../../util/moduleManifestUtil";
 import { jsonStringifyError } from "../../../util/jsonStringifyError";
 
 export default async function send(
@@ -14,16 +17,23 @@ export default async function send(
   }
 
   const body: SendPreviewRequestBody = req.body;
-  const { to, subject, previewClass, previewFunction } = body;
-  let component;
+  const { to, previewClass, previewFunction } = body;
+  let component, template;
+  let subject = `${previewClass} - ${previewFunction}`;
 
   if (previewClass && previewFunction) {
     component = await getPreviewComponent(previewClass, previewFunction);
+    template = await getTemplateModule(previewClass);
   }
+
   if (!component) {
     error("no component found");
     res.status(400).json({ error: "no html provided, no component found" });
     return;
+  }
+
+  if (template && typeof template.subject === "function") {
+    subject = template.subject(component.props);
   }
 
   try {

--- a/packages/cli/src/pages/api/previews/send.ts
+++ b/packages/cli/src/pages/api/previews/send.ts
@@ -18,22 +18,22 @@ export default async function send(
 
   const body: SendPreviewRequestBody = req.body;
   const { to, previewClass, previewFunction } = body;
-  let component, template;
   let subject = `${previewClass} - ${previewFunction}`;
 
-  if (previewClass && previewFunction) {
-    component = await getPreviewComponent(previewClass, previewFunction);
-    template = await getTemplateModule(previewClass);
-  }
-
+  const component = await getPreviewComponent(previewClass, previewFunction);
   if (!component) {
     error("no component found");
     res.status(400).json({ error: "no html provided, no component found" });
     return;
   }
 
-  if (template && typeof template.subject === "function") {
-    subject = template.subject(component.props);
+  const template = getTemplateModule(previewClass);
+  if (template) {
+    if (typeof template.subject === "function") {
+      subject = template.subject(component.props);
+    } else if (typeof template.subject === "string") {
+      subject = template.subject;
+    }
   }
 
   try {

--- a/packages/cli/src/pages/api/sendMail.ts
+++ b/packages/cli/src/pages/api/sendMail.ts
@@ -32,11 +32,6 @@ export default async function handler(
     return res.status(403).json({ error: "to, cc, or bcc must be specified" });
   }
 
-  // validate subject
-  if (typeof mailOptions.subject !== "string") {
-    return res.status(403).json({ error: "subject must be specified" });
-  }
-
   if (!html) {
     // validate template name
     if (typeof templateName !== "string") {

--- a/packages/cli/src/util/moduleManifestUtil.ts
+++ b/packages/cli/src/util/moduleManifestUtil.ts
@@ -1,4 +1,5 @@
 import { JSXElementConstructor, ReactElement } from "react";
+import { Template } from "mailing-core";
 import moduleManifest, { config } from "../moduleManifest";
 
 export function previewTree(): [string, string[]][] {

--- a/packages/cli/src/util/moduleManifestUtil.ts
+++ b/packages/cli/src/util/moduleManifestUtil.ts
@@ -14,10 +14,12 @@ export function previewTree(): [string, string[]][] {
   });
 }
 
-export function getTemplateModule(name: string) {
+export function getTemplateModule(name?: string) {
+  if (!name) return null;
+
   return moduleManifest.templates[
     name as keyof typeof moduleManifest.templates
-  ];
+  ] as unknown as Template<any>;
 }
 
 export function getPreviewModule(name: string) {

--- a/packages/cli/src/util/moduleManifestUtil.ts
+++ b/packages/cli/src/util/moduleManifestUtil.ts
@@ -14,6 +14,12 @@ export function previewTree(): [string, string[]][] {
   });
 }
 
+export function getTemplateModule(name: string) {
+  return moduleManifest.templates[
+    name as keyof typeof moduleManifest.templates
+  ];
+}
+
 export function getPreviewModule(name: string) {
   return moduleManifest.previews[name as keyof typeof moduleManifest.previews];
 }
@@ -29,6 +35,7 @@ export async function getPreviewComponent(
       }
     | undefined = previews[name as keyof typeof previews] as any;
   const previewComponent = previewModule?.[functionName];
+
   return typeof previewComponent === "function"
     ? await previewComponent()
     : undefined;

--- a/packages/core/src/__test__/index.test.tsx
+++ b/packages/core/src/__test__/index.test.tsx
@@ -29,6 +29,81 @@ describe("index", () => {
     },
   });
 
+  beforeEach(async () => {
+    await clearTestMailQueue();
+  });
+
+  describe("subject", () => {
+    it("throws an error if missing subject", () => {
+      const sendMail = buildSendMail({
+        transport,
+        defaultFrom: "replace@me.with.your.com",
+        configPath: "./mailing.config.json",
+      });
+
+      const callSendMail = async () =>
+        await sendMail({
+          component: <div></div>,
+          to: ["ok@ok.com"],
+          from: "ok@ok.com",
+          text: "ok",
+          html: "ok",
+        });
+
+      expect(callSendMail()).rejects.toThrowError(
+        "sendMail couldn't find a subject for your email"
+      );
+    });
+    
+    it("should use subject from options", async () => {
+      const sendMail = buildSendMail({
+        transport,
+        defaultFrom: "replace@me.with.your.com",
+        configPath: "./mailing.config.json",
+      });
+
+      await sendMail({
+        component: <div></div>,
+        to: ["ok@ok.com"],
+        from: "ok@ok.com",
+        subject: "hello",
+        text: "ok",
+        html: "ok",
+      });
+
+      // still hits the queue even with the error
+      const queue = await getTestMailQueue();
+      expect(queue.length).toBe(1);
+      const email = queue[0];
+      expect(email.subject).toEqual("hello");
+    });
+
+    it("should use subject from the component", async () => {
+      const sendMail = buildSendMail({
+        transport,
+        defaultFrom: "replace@me.with.your.com",
+        configPath: "./mailing.config.json",
+      });
+
+      const Component = ({ name }: { name: string }) => <div>{name}</div>;
+      Component.subject = ({ name }: { name: string }) => `Hello ${name}`;
+
+      await sendMail({
+        component: <Component name="Gerald" />,
+        to: ["ok@ok.com"],
+        from: "ok@ok.com",
+        text: "ok",
+        html: "ok",
+      });
+
+      // still hits the queue even with the error
+      const queue = await getTestMailQueue();
+      expect(queue.length).toBe(1);
+      const email = queue[0];
+      expect(email.subject).toEqual("Hello Gerald");
+    });
+  });
+
   describe("analyticsEnabled: false", () => {
     const OLD_ENV = process.env;
 
@@ -75,7 +150,6 @@ describe("index", () => {
       });
 
       it("logs an error without a valid configPath but still sends", async () => {
-        await clearTestMailQueue();
         const debugSpy = jest.spyOn(log, "debug").mockImplementation(jest.fn());
 
         const sendMail = buildSendMail({
@@ -291,7 +365,6 @@ describe("index", () => {
     describe("getTestMailQueue", () => {
       let sendMail: (mail: ComponentMail) => Promise<any>;
       beforeEach(async () => {
-        await clearTestMailQueue();
         const transport = nodemailer.createTransport({
           pool: true,
           host: "smtp.example.com",
@@ -371,6 +444,7 @@ describe("index", () => {
             listName: "mylista4290",
             dangerouslyForceDeliver: true,
             html: "No unsubscribe link here",
+            subject: "hello",
           });
 
         expect(callSendMail).rejects.toThrowError(

--- a/packages/core/src/__test__/index.test.tsx
+++ b/packages/core/src/__test__/index.test.tsx
@@ -54,7 +54,7 @@ describe("index", () => {
         "sendMail couldn't find a subject for your email"
       );
     });
-    
+
     it("should use subject from options", async () => {
       const sendMail = buildSendMail({
         transport,
@@ -78,7 +78,7 @@ describe("index", () => {
       expect(email.subject).toEqual("hello");
     });
 
-    it("should use subject from the component", async () => {
+    it("should use subject from the component - subject is function", async () => {
       const sendMail = buildSendMail({
         transport,
         defaultFrom: "replace@me.with.your.com",
@@ -101,6 +101,31 @@ describe("index", () => {
       expect(queue.length).toBe(1);
       const email = queue[0];
       expect(email.subject).toEqual("Hello Gerald");
+    });
+
+    it("should use subject from the component - subject is string", async () => {
+      const sendMail = buildSendMail({
+        transport,
+        defaultFrom: "replace@me.with.your.com",
+        configPath: "./mailing.config.json",
+      });
+
+      const Component = ({ name }: { name: string }) => <div>{name}</div>;
+      Component.subject = "Hello world";
+
+      await sendMail({
+        component: <Component name="Gerald" />,
+        to: ["ok@ok.com"],
+        from: "ok@ok.com",
+        text: "ok",
+        html: "ok",
+      });
+
+      // still hits the queue even with the error
+      const queue = await getTestMailQueue();
+      expect(queue.length).toBe(1);
+      const email = queue[0];
+      expect(email.subject).toEqual("Hello world");
     });
   });
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,6 +28,11 @@ export type ComponentMail = SendMailOptions & {
   listName?: string;
 };
 
+export type Template<P> = React.FC<P> & {
+  subject?: string | ((args: Partial<P>) => string);
+};
+
+
 export async function getTestMailQueue() {
   try {
     const queue = await fs.readFile(TMP_TEST_FILE);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -112,8 +112,18 @@ export function buildSendMail<T>(options: BuildSendMailOptions<T>) {
       derivedTemplateName = component.type.name;
       mailOptions.html = renderedHtml;
     }
-
     if (!mailOptions.html) throw new Error("sendMail couldn't find your html");
+
+    // Get subject from the component if not provided
+    if (component && !mailOptions.subject) {
+      if (typeof component.type.subject === "string") {
+        mailOptions.subject = component.type.subject;
+      } else if (typeof component.type.subject === "function") {
+        mailOptions.subject = component.type.subject(component.props);
+      }
+    }
+    if (!mailOptions.subject)
+      throw new Error("sendMail couldn't find a subject for your email");
 
     if (testMode && !dangerouslyForceDeliver) {
       const testMessageQueue = await getTestMailQueue();


### PR DESCRIPTION
## Describe your changes
Adds the ability to define email subjects along side an email template, and uses that when sending emails if no subject is passed in.

## Issue link
Part of #348


## Checklist before requesting a review

- [X] I have performed a self-review of my code
- [X] If it is a core feature, I have added thorough tests.
