### PR TITLE
use 422 response codes

### DIFF
--- a/packages/cli/src/pages/api/__integration__/sendMail.test.ts
+++ b/packages/cli/src/pages/api/__integration__/sendMail.test.ts
@@ -68,7 +68,7 @@ describe("sendMail", () => {
           ...ApiSendMail.defaultFormData,
           templateName: "ThisIsNotATemplate",
         });
-      expect(sendMailResponseWithBadTemplateName.status).toBe(404);
+      expect(sendMailResponseWithBadTemplateName.status).toBe(422);
       const errorJson = await sendMailResponseWithBadTemplateName.json();
 
       expect("error" in errorJson).toBe(true);

--- a/packages/cli/src/pages/api/__test__/sendMail.test.ts
+++ b/packages/cli/src/pages/api/__test__/sendMail.test.ts
@@ -1,0 +1,66 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { sendMail } from "../../../moduleManifest";
+import handler from "../sendMail";
+
+// api authentication is tested in __integration__/sendMail.test.ts so don't also test it here
+jest.mock("../../../util/validateApiKey", () => ({
+  validateApiKey: async () => true,
+}));
+
+jest.mock("../../../moduleManifest", () => {
+  const originalModule = jest.requireActual("../../../moduleManifest");
+  return {
+    ...originalModule,
+    sendMail: jest.fn(),
+  };
+});
+
+function mockRequestResponse(method: string) {
+  const { req, res } = {
+    req: { method } as NextApiRequest,
+    res: {} as unknown as NextApiResponse,
+  };
+  res.json = jest.fn();
+  res.end = jest.fn();
+  req.query = {};
+  res.status = jest.fn(() => res);
+  req.body = {
+    to: "alex@mailing.run",
+    templateName: "AccountCreated",
+    subject: "Welcome to Mailing!",
+    props: { name: "Alex" },
+  };
+  req.headers = { "Content-Type": "application/json" };
+  return { req, res };
+}
+
+describe("sendMail with a valid api key", () => {
+  beforeAll(() => {});
+
+  it("should 422 if no to, cc, or bcc is provided", async () => {
+    const { req, res } = mockRequestResponse("POST");
+    delete req.body.to;
+    await handler(req, res);
+    expect(res.status).toHaveBeenCalledWith(422);
+    expect(res.json).toHaveBeenCalledWith({
+      error: "to, cc, or bcc must be specified",
+    });
+  });
+
+  it("should 422 if no templateName is provided", async () => {
+    const { req, res } = mockRequestResponse("POST");
+    delete req.body.templateName;
+    await handler(req, res);
+    expect(res.status).toHaveBeenCalledWith(422);
+    expect(res.json).toHaveBeenCalledWith({
+      error: "templateName or html must be specified",
+    });
+  });
+
+  it("should 200 with everything correctly given", async () => {
+    const { req, res } = mockRequestResponse("POST");
+    await handler(req, res);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(sendMail).toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/pages/api/sendMail.ts
+++ b/packages/cli/src/pages/api/sendMail.ts
@@ -29,14 +29,14 @@ export default async function handler(
     typeof mailOptions.cc === "undefined" &&
     typeof mailOptions.bcc === "undefined"
   ) {
-    return res.status(403).json({ error: "to, cc, or bcc must be specified" });
+    return res.status(422).json({ error: "to, cc, or bcc must be specified" });
   }
 
   if (!html) {
     // validate template name
     if (typeof templateName !== "string") {
       return res
-        .status(403)
+        .status(422)
         .json({ error: "templateName or html must be specified" });
     }
 
@@ -48,7 +48,7 @@ export default async function handler(
     } = renderTemplate(templateName.replace(/\.[jt]sx?$/, ""), props);
 
     if (error) {
-      return res.status(404).json({ error, mjmlErrors });
+      return res.status(422).json({ error, mjmlErrors });
     }
     html = renderedHtml;
   }

--- a/packages/cli/src/util/validateApiKey.ts
+++ b/packages/cli/src/util/validateApiKey.ts
@@ -16,7 +16,9 @@ export async function validateApiKey(
   if (process.env.MAILING_INTEGRATION_TEST && "testApiKey" === apiKey)
     return true;
   if (typeof apiKey !== "string") {
-    res.status(422).end("expected x-api-key in header or apiKey in query");
+    res
+      .status(422)
+      .json({ error: "expected x-api-key in header or apiKey in query" });
     return false;
   }
 
@@ -35,7 +37,7 @@ export async function validateApiKey(
 
     return true;
   } catch {
-    res.status(401).end("API key is not valid");
+    res.status(401).json({ error: "API key is not valid" });
   }
 
   return false;


### PR DESCRIPTION
In this update:
- sendMail returns 422 response codes instead of 403
- change the response code from 404 to 422 if you pass an invalid template name
- the http responses for an invalid api key to use json instead of plaintext
- adds tests for the above