### PR TITLE
fix: prevent intercept error when `from` is object

### DIFF
--- a/.changeset/sweet-berries-know.md
+++ b/.changeset/sweet-berries-know.md
@@ -1,0 +1,6 @@
+---
+"mailing": patch
+"mailing-core": patch
+---
+
+fix: prevent intercept error when from is object

--- a/packages/cli/src/components/Intercept.tsx
+++ b/packages/cli/src/components/Intercept.tsx
@@ -101,7 +101,14 @@ const Intercept: React.FC<InterceptProps> = ({ data }) => {
         <div>
           <div>Subject: {data.subject ? `"${data.subject}"` : "MISSING"}</div>
           {data.to && <div>To: {data.to}</div>}
-          <div>From: {data.from || "MISSING"}</div>
+          <div>
+            From:{' '}
+            {!data.from
+              ? 'MISSING'
+              : typeof data.from === 'string'
+              ? data.from
+              : `${data.from.name} <${data.from.address}>`}
+          </div>
           {data.cc && <div>CC: {data.cc}</div>}
           {data.bcc && <div>BCC: {data.bcc}</div>}
         </div>

--- a/packages/cli/src/custom.d.ts
+++ b/packages/cli/src/custom.d.ts
@@ -2,7 +2,7 @@ type Intercept = {
   id: string;
   html: string;
   to?: string | string[];
-  from?: string;
+  from?: string | { name: string; address: string };
   subject?: string;
   cc?: string | string[];
   bcc?: string | string[];

--- a/packages/cli/src/pages/intercepts/mock.tsx
+++ b/packages/cli/src/pages/intercepts/mock.tsx
@@ -5,7 +5,7 @@ const ShowIntercept = () => {
     id: "mock",
     html: "<html><body><h1>Title</h1>hope it's not too strict</body></html>",
     to: "peter s. <peter+test@campsh.com>",
-    from: "peter+sendgrid@campsh.com",
+    from: { name: "peter", address: "peter+sendgrid@campsh.com" },
     subject: "A test email",
   };
 


### PR DESCRIPTION
## Describe your changes

This prevents the intercept page breaking when `from` is an object instead of a string.

When you call `sendMail` like this:
```ts
sendMail({
  from: { name: "Some name", address: "some.name@example.com" },
});
```

It breaks when intercepted:

```console
Uncaught Error: Objects are not valid as a React child (found: object with keys {name, address}). If you meant to render a collection of children, use an array instead.
```

NOTE: I wasn't sure how to actually test this locally, so hopefully my changes are good. Let me know if there's an easy way to send emails for interception.

## Issue link

N/A

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
