### PR TITLE
fix: allow custom preview server url

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -2,6 +2,7 @@ name: Cypress Tests
 
 on:
   push:
+  pull_request:
 
 jobs:
   cypress:

--- a/.github/workflows/cypress_integration.yml
+++ b/.github/workflows/cypress_integration.yml
@@ -2,6 +2,7 @@ name: Cypress Integration Tests
 
 on:
   push:
+  pull_request:
 
 jobs:
   cypress:

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -1,6 +1,7 @@
 name: Eslint
 on:
   push:
+  pull_request:
 jobs:
   eslint:
     runs-on: ubuntu-latest

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -5,6 +5,7 @@
 name: Jest Tests
 on:
   push:
+  pull_request:
 jobs:
   jest:
     runs-on: ubuntu-latest

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,6 +1,7 @@
 name: Rubocop
 on:
   push:
+  pull_request:
 jobs:
   rubocop:
     runs-on: ubuntu-latest

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -253,7 +253,7 @@ export function buildSendMail<T>(options: BuildSendMailOptions<T>) {
   };
 }
 
-async function openPreview(
+export async function openPreview(
   mail: ComponentMail,
   mailOptions: SendMailOptions,
   previewServerUrl?: string
@@ -278,6 +278,7 @@ async function openPreview(
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(mailOptions),
     });
+
     if (response.status === 201) {
       const { id } = (await response.json()) as { id: string };
       await open(`${PREVIEW_SERVER_URL}/${id}`);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -33,6 +33,7 @@ export type ComponentMail = SendMailOptions & {
   component?: JSX.Element;
   dangerouslyForceDeliver?: boolean;
   forcePreview?: boolean;
+  previewServerUrl?: string;
   templateName?: string;
   previewName?: string;
   listName?: string;
@@ -105,6 +106,7 @@ export function buildSendMail<T>(options: BuildSendMailOptions<T>) {
       dangerouslyForceDeliver,
       templateName,
       previewName,
+      previewServerUrl,
       forcePreview,
       listName,
       ...mailOptions
@@ -164,7 +166,7 @@ export function buildSendMail<T>(options: BuildSendMailOptions<T>) {
       log("💌 opening sendMail preview", debugMail);
       // create an intercept on the preview server
       // then open it in the browser
-      const PREVIEW_SERVER_URL = "http://localhost:3883/intercepts";
+      const PREVIEW_SERVER_URL = `${previewServerUrl?.trim().replace(/\/+$/, "") || "http://localhost:3883"}/intercepts`;
       try {
         const response = await fetch(PREVIEW_SERVER_URL, {
           method: "POST",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -159,31 +159,7 @@ export function buildSendMail<T>(options: BuildSendMailOptions<T>) {
       await fs.writeFile(TMP_TEST_FILE, JSON.stringify(testMessageQueue));
       return;
     } else if (previewMode) {
-      const debugMail = {
-        ...mail,
-        html: "omitted",
-      };
-      log("💌 opening sendMail preview", debugMail);
-      // create an intercept on the preview server
-      // then open it in the browser
-      const PREVIEW_SERVER_URL = `${previewServerUrl?.trim().replace(/\/+$/, "") || "http://localhost:3883"}/intercepts`;
-      try {
-        const response = await fetch(PREVIEW_SERVER_URL, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(mailOptions),
-        });
-        if (response.status === 201) {
-          const { id } = (await response.json()) as { id: string };
-          await open(`${PREVIEW_SERVER_URL}/${id}`);
-        } else {
-          error(`Error hitting ${PREVIEW_SERVER_URL}`);
-          error(response);
-        }
-      } catch (e) {
-        error(`Caught error 1 ${e}`);
-        error("Is the mailing preview server running?");
-      }
+      await openPreview(mail, mailOptions, previewServerUrl);
       return;
     }
 
@@ -275,6 +251,44 @@ export function buildSendMail<T>(options: BuildSendMailOptions<T>) {
 
     return response;
   };
+}
+
+async function openPreview(
+  mail: ComponentMail,
+  mailOptions: SendMailOptions,
+  previewServerUrl?: string
+) {
+  const debugMail = {
+    ...mail,
+    html: "omitted",
+  };
+
+  log("💌 opening sendMail preview", debugMail);
+
+  // create an intercept on the preview server
+  // then open it in the browser
+  const PREVIEW_SERVER_URL =
+    ("string" === typeof previewServerUrl
+      ? previewServerUrl.trim().replace(/\/+$/, "")
+      : "http://localhost:3883") + "/intercepts";
+
+  try {
+    const response = await fetch(PREVIEW_SERVER_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(mailOptions),
+    });
+    if (response.status === 201) {
+      const { id } = (await response.json()) as { id: string };
+      await open(`${PREVIEW_SERVER_URL}/${id}`);
+    } else {
+      error(`Error hitting ${PREVIEW_SERVER_URL}`);
+      error(response);
+    }
+  } catch (e) {
+    error(`Caught error 1 ${e}`);
+    error("Is the mailing preview server running?");
+  }
 }
 
 export { buildSendMail as default, render };

--- a/packages/web/pages/docs/sending-email.mdx
+++ b/packages/web/pages/docs/sending-email.mdx
@@ -62,6 +62,7 @@ Sends an email using the configured transport. It extends the `sendMail` functio
 - `component` – The React component to render as the email body. If you pass in a string for `html`, this will be ignored
 - `dangerouslyForceDeliver` – If true, the email will be sent even if the `NODE_ENV` is not `production`. Use with caution.
 - `forcePreview` – If true, the email will be intercepted by the preview server
+- `previewServerUrl` – If you have changed the port of the mailing preview server, you can set it here (default: `http://localhost:3883`)
 - `listName` – The name of the list to send the email to. [Read more about lists](/docs/lists)
 - `from` – The email address of the sender. If not provided, the defaultFrom address configured in `buildSendMail` will be used.
 - `to` – Comma separated list or an array of recipients email addresses that will appear on the To: field


### PR DESCRIPTION
## Describe your changes

At the moment the intercept URL is hard coded, despite allowing the preview server to live at a different port via the --port flag

NOTE: My understanding is that adding this variable is necessary since I don't see a way to propagate the --port flag for the server over to the `mailing-core` package (I could be wrong, if so feel free to overwrite / let me know so I can fix).

ALSO NOTE: I did not test this again, apologies I just thought this would be higher value than opening up an issue and didn't want to dig too deep.

## Issue link

N/A

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
