### PR TITLE
add doc sentence about forcing ts mode

### DIFF
--- a/packages/web/pages/docs/index.mdx
+++ b/packages/web/pages/docs/index.mdx
@@ -36,7 +36,7 @@ Mailing is a tool for building, testing, and sending emails with React.
   </CodeBlock>
 </CodeBlocks>
 
-2. Run `npx mailing` to start the preview server and scaffold your `emails` directory. This will create the following directory for all of your emails:
+2. Run `npx mailing` to start the preview server and scaffold your `emails` directory. To force TypeScript mode, run `npx mailing --typescript`. This will create the following directory for all of your emails:
 
 ```
 emails


### PR DESCRIPTION
## Describe your changes

A few people have found it confusing that we default to js if a tsconfig is not found. I'd like to re-introduce the prompt where you pick if we don't see a tsconfig, but this will have to do in the meantime.