### PR TITLE
411 jest tests have version of expect that is clobbered by cypress instead of expected jest version

### DIFF
--- a/packages/cli/cypress/tsconfig.json
+++ b/packages/cli/cypress/tsconfig.json
@@ -4,5 +4,5 @@
     "lib": ["es5", "dom"],
     "types": ["cypress", "node"]
   },
-  "include": ["**/*.ts"]
+  "include": ["**/*.ts", "../cypress*.ts"]
 }

--- a/packages/cli/src/util/postHog/__test__/postHog.test.ts
+++ b/packages/cli/src/util/postHog/__test__/postHog.test.ts
@@ -8,12 +8,11 @@ describe("postHog", () => {
   const MM_DEV_OG = process.env.MM_DEV;
   const MM_DEV_E2E_OG = process.env.MM_E2E;
   let mockPostHogClient: PostHog;
-  let mockPostHogClient2: PostHog;
+  let mockPostHogClientWithShutdownError: PostHog;
 
   beforeEach(() => {
     mockPostHogClient = { capture: jest.fn() } as unknown as PostHog;
-    mockPostHogClient2 = {
-      capture: jest.fn(),
+    mockPostHogClientWithShutdownError = {
       shutdownAsync: jest.fn().mockRejectedValue(new Error("timeout")),
     } as unknown as PostHog;
     jest.restoreAllMocks();
@@ -29,9 +28,9 @@ describe("postHog", () => {
   it("should not raise an error if posthog shutdown raises an error (e.g. a timeout)", async () => {
     jest
       .spyOn(postHogClient, "getPostHogClient")
-      .mockImplementation(() => mockPostHogClient2);
+      .mockImplementation(() => mockPostHogClientWithShutdownError);
 
-    await expect(async () => {
+    expect(async () => {
       await shutdown();
     }).not.toThrow();
   });

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -24,6 +24,7 @@
   "include": ["./*.ts", "src/**/*.ts", "src/**/*.tsx", "prisma/**/*.ts"],
   "exclude": [
     "dist/**/*",
-    "node_modules"
+    "node_modules",
+    "./cypress*.ts"
   ]
 }


### PR DESCRIPTION
- fix #411 by   excluding cypress related files in packages/cli/tsconfig.json and including them in packages/cli/cypress/tsconfig.json
- in postHog test:     remove superflous await now that typescript is working again and give this mock a better name