### PR TITLE
update ui active color; new tailwind color 'active'

### DIFF
--- a/.changeset/warm-ligers-count.md
+++ b/.changeset/warm-ligers-count.md
@@ -1,0 +1,6 @@
+---
+"mailing": patch
+"mailing-core": patch
+---
+
+switch to neutral ui active colors that are unlikely to clash with brand colors in emails

--- a/packages/cli/src/components/Header.tsx
+++ b/packages/cli/src/components/Header.tsx
@@ -11,7 +11,6 @@ import IconQuestion from "./icons/IconQuestion";
 import IconSend from "./icons/IconSend";
 
 const white = "#E4EBFA";
-const gray = "#333";
 
 type HeaderProps = {
   previewFunction?: string;
@@ -37,27 +36,27 @@ const Header: React.FC<HeaderProps> = ({
         <div className="segmented-control">
           <button
             className={cx("desktop cursor-pointer hover:bg-gray-700", {
-              active: viewMode === "desktop",
+              "bg-active": viewMode === "desktop",
             })}
             onClick={() => setViewMode("desktop")}
           >
-            <IconDesktop fill={viewMode === "desktop" ? gray : white} />
+            <IconDesktop fill={white} />
           </button>
           <button
             className={cx("mobile cursor-pointer hover:bg-gray-700", {
-              active: viewMode === "mobile",
+              "bg-active": viewMode === "mobile",
             })}
             onClick={() => setViewMode("mobile")}
           >
-            <IconMobile fill={"mobile" === viewMode ? gray : white} />
+            <IconMobile fill={white} />
           </button>
           <button
             className={cx("html cursor-pointer hover:bg-gray-700", {
-              active: viewMode === "html",
+              "bg-active": viewMode === "html",
             })}
             onClick={() => setViewMode("html")}
           >
-            <IconCode fill={"html" === viewMode ? gray : white} />
+            <IconCode fill={white} />
           </button>
         </div>
       </div>
@@ -95,7 +94,6 @@ const Header: React.FC<HeaderProps> = ({
       <style jsx>{`
         .header {
           height: 52px;
-          border-bottom: 1px dotted #333;
           display: flex;
           justify-content: space-between;
           align-items: center;
@@ -126,7 +124,7 @@ const Header: React.FC<HeaderProps> = ({
 
         button {
           height: 36px;
-          border: 1px dotted #333;
+          border: 1px dotted #555;
           transition: background-color, box-shadow 200ms ease-out;
           text-align: center;
         }
@@ -161,10 +159,6 @@ const Header: React.FC<HeaderProps> = ({
           border-left: none;
           border-top-right-radius: 16px;
           border-bottom-right-radius: 16px;
-        }
-        .active {
-          background: #b8ceff;
-          border-color: transparent;
         }
         .help,
         .send {

--- a/packages/cli/src/components/IndexPane/ClientView.tsx
+++ b/packages/cli/src/components/IndexPane/ClientView.tsx
@@ -36,7 +36,7 @@ const ClientView: React.FC<ClientViewProps> = ({
             aria-label={`${route.previewClass} - ${route.previewFunction}`}
             className={cx("rounded-2xl cursor-pointer", {
               "pl-1": route.level === 2,
-              "bg-blue text-black -mt-px pt-px": isCursor,
+              "bg-active text-white -mt-px pt-px": isCursor,
               "hover:bg-neutral-900 hover:-mt-px hover:pt-px": !isCursor,
             })}
             onClick={() => navigate(i)}
@@ -51,12 +51,7 @@ const ClientView: React.FC<ClientViewProps> = ({
                 {route.previewClass} / {route.previewFunction}
               </div>
               <div className="pb-px">{subject}</div>
-              <div
-                className={cx("line-clamp-2 leading-tight", {
-                  "text-gray-300": !isCursor,
-                  "text-gray-600": isCursor,
-                })}
-              >
+              <div className="line-clamp-2 leading-tight text-gray-300">
                 {previewText}
               </div>
             </div>

--- a/packages/cli/src/components/IndexPane/CompactView.tsx
+++ b/packages/cli/src/components/IndexPane/CompactView.tsx
@@ -54,7 +54,7 @@ const CompactView: React.FC<CompactViewProps> = ({
               "pl-2": route.level === 0,
               "pl-6": route.level === 1,
               "pl-[70px] pb-1 pt-1": route.level === 2,
-              "bg-blue text-black rounded-2xl": i === cursor,
+              "bg-active rounded-2xl": i === cursor,
             })}
             onClick={handleClick(i, route.collapsed)}
           >
@@ -71,10 +71,8 @@ const CompactView: React.FC<CompactViewProps> = ({
                   fill="none"
                   xmlns="http://www.w3.org/2000/svg"
                   className={cx(
-                    "inline origin-center arrow transition-transform",
+                    "stroke-white inline origin-center arrow transition-transform",
                     {
-                      "stroke-black": i === cursor,
-                      "stroke-white": i !== cursor,
                       "collapsed -rotate-90 relative -top-px": route.collapsed,
                     }
                   )}

--- a/packages/cli/theme.js
+++ b/packages/cli/theme.js
@@ -29,6 +29,7 @@ module.exports = {
       ],
     },
     colors: {
+      active: "#444",
       white: "#e4ebfa",
       "gray-300": "#ccc",
       "gray-500": "#555",


### PR DESCRIPTION
Updates to neutral ui active colors that are unlikely to clash with brand colors in the emails. Before was blue, now this:
<img width="925" alt="Screen Shot 2022-12-08 at 8 45 48 PM" src="https://user-images.githubusercontent.com/282016/206625954-8c9af513-d332-46f2-88cc-1b652acf1051.png">
<img width="918" alt="Screen Shot 2022-12-08 at 8 45 34 PM" src="https://user-images.githubusercontent.com/282016/206625963-b505d075-2ad5-44fa-96b5-a3fbc0b3e0c2.png">

