### PR TITLE
docs: Update REST API example

### DIFF
--- a/packages/web/pages/docs/rest-api.mdx
+++ b/packages/web/pages/docs/rest-api.mdx
@@ -72,12 +72,12 @@ is included in the request.
       headers: {
         "Content-Type": "application/json",
       },
-      body: {
+      body: JSON.stringify({
         "templateName": "myTemplate",
         "props": {
           "name": "Alex"
         },
-      }
+      }),
     });
     ```
 


### PR DESCRIPTION
## Describe your changes
Updates the documentation for how to use the Mailing REST API to request the compiled html for a template. The current example does not use JSON.stringify to convert a JavaScript value to a JSON string, which will result in an error if someone tries to do a fetch request. 

I tested this locally, to make sure the formatting of the code block matches the JavaScript example further down the page for the `api/sendMail` endpoint.

![Screenshot 2023-01-27 at 12 43 49 PM](https://user-images.githubusercontent.com/4039311/215170250-18bff6fe-21a9-401f-a06a-4802b3040239.png)


## Issue link
No Github issue for this

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
