### PR TITLE
replace `mjml-react` with `@faire/mjml-react` and fix types issues

### DIFF
--- a/.changeset/plenty-mice-call.md
+++ b/.changeset/plenty-mice-call.md
@@ -1,0 +1,7 @@
+---
+"mailing": minor
+"mailing-core": minor
+"web": minor
+---
+
+Use @faire/mjml-react react bindings

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,6 +48,7 @@
   },
   "dependencies": {
     "@babel/parser": "^7.18.11",
+    "@faire/mjml-react": "^3.1.2",
     "@prisma/client": "^4.4.0",
     "@reecelucas/react-use-hotkeys": "^1.3.5",
     "@tailwindcss/line-clamp": "^0.4.2",
@@ -56,7 +57,6 @@
     "@types/html-minifier-terser": "^6.1.0",
     "@types/lodash": "^4.14.184",
     "@types/mjml": "^4.7.0",
-    "@types/mjml-react": "^2.0.4",
     "@types/node": "^17.0.24",
     "@types/node-fetch": "^2.6.1",
     "@types/nodemailer": "^6.4.4",
@@ -78,7 +78,6 @@
     "lodash": "^4.17.21",
     "mailing-core": "^0.9.12",
     "mjml": "^4.12.0",
-    "mjml-react": "^2.0.7",
     "node-fetch": "^2.6.7",
     "node-html-parser": "^6.1.1",
     "nodemailer": "6.8.0",

--- a/packages/cli/src/__mocks__/emails-js/AccountCreated.jsx
+++ b/packages/cli/src/__mocks__/emails-js/AccountCreated.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { MjmlSection, MjmlColumn, MjmlImage } from "mjml-react";
+import { MjmlSection, MjmlColumn, MjmlImage } from "@faire/mjml-react";
 import Button from "./components/Button";
 import Header from "./components/Header";
 import Heading from "./components/Heading";

--- a/packages/cli/src/__mocks__/emails-js/NewSignIn.jsx
+++ b/packages/cli/src/__mocks__/emails-js/NewSignIn.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { MjmlSection, MjmlColumn, MjmlSpacer } from "mjml-react";
+import { MjmlSection, MjmlColumn, MjmlSpacer } from "@faire/mjml-react";
 import Header from "./components/Header";
 import Heading from "./components/Heading";
 import Footer from "./components/Footer";

--- a/packages/cli/src/__mocks__/emails-js/Reservation.jsx
+++ b/packages/cli/src/__mocks__/emails-js/Reservation.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { MjmlSection, MjmlColumn } from "mjml-react";
+import { MjmlSection, MjmlColumn } from "@faire/mjml-react";
 import Header from "./components/Header";
 import Heading from "./components/Heading";
 import Footer from "./components/Footer";

--- a/packages/cli/src/__mocks__/emails-js/ResetPassword.jsx
+++ b/packages/cli/src/__mocks__/emails-js/ResetPassword.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { MjmlSection, MjmlColumn } from "mjml-react";
+import { MjmlSection, MjmlColumn } from "@faire/mjml-react";
 import Header from "./components/Header";
 import Footer from "./components/Footer";
 import Button from "./components/Button";

--- a/packages/cli/src/__mocks__/emails-js/components/BaseLayout.jsx
+++ b/packages/cli/src/__mocks__/emails-js/components/BaseLayout.jsx
@@ -9,7 +9,7 @@ import {
   MjmlAll,
   MjmlRaw,
   MjmlPreview,
-} from "mjml-react";
+} from "@faire/mjml-react";
 import { colors, screens, themeDefaults, spacing } from "../theme";
 
 export default function BaseLayout({ width, children, preview }) {

--- a/packages/cli/src/__mocks__/emails-js/components/Button.jsx
+++ b/packages/cli/src/__mocks__/emails-js/components/Button.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { MjmlButton } from "mjml-react";
+import { MjmlButton } from "@faire/mjml-react";
 import { colors, fontSize, borderRadius, lineHeight, spacing } from "../theme";
 
 export default function Button(props) {

--- a/packages/cli/src/__mocks__/emails-js/components/Divider.jsx
+++ b/packages/cli/src/__mocks__/emails-js/components/Divider.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { MjmlDivider } from "mjml-react";
+import { MjmlDivider } from "@faire/mjml-react";
 import { colors } from "../theme";
 
 const defaultProps = {

--- a/packages/cli/src/__mocks__/emails-js/components/Footer.jsx
+++ b/packages/cli/src/__mocks__/emails-js/components/Footer.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { MjmlSection, MjmlColumn, MjmlText } from "mjml-react";
+import { MjmlSection, MjmlColumn, MjmlText } from "@faire/mjml-react";
 import { EMAIL_PREFERENCES_URL } from "mailing-core";
 import { colors, fontSize, spacing } from "../theme";
 

--- a/packages/cli/src/__mocks__/emails-js/components/Header.jsx
+++ b/packages/cli/src/__mocks__/emails-js/components/Header.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { MjmlSection, MjmlColumn, MjmlImage } from "mjml-react";
+import { MjmlSection, MjmlColumn, MjmlImage } from "@faire/mjml-react";
 
 const Header = ({ loose }) => {
   return (

--- a/packages/cli/src/__mocks__/emails-js/components/List.jsx
+++ b/packages/cli/src/__mocks__/emails-js/components/List.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { MjmlRaw } from "mjml-react";
+import { MjmlRaw } from "@faire/mjml-react";
 import { themeDefaults } from "../theme";
 
 export default function List({ items }) {

--- a/packages/cli/src/__mocks__/emails-js/components/Text.jsx
+++ b/packages/cli/src/__mocks__/emails-js/components/Text.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { MjmlText } from "mjml-react";
+import { MjmlText } from "@faire/mjml-react";
 
 export default function Text({ children, maxWidth, ...props }) {
   if (maxWidth) {

--- a/packages/cli/src/__mocks__/emails-js/theme.js
+++ b/packages/cli/src/__mocks__/emails-js/theme.js
@@ -10,19 +10,19 @@ export const colors = {
   neutral800: "#444",
 };
 export const fontSize = {
-  xs: 12,
-  sm: 14,
-  base: 16,
-  lg: 24,
-  xl: 30,
+  xs: "12px",
+  sm: "14px",
+  base: "16px",
+  lg: "24px",
+  xl: "30px",
 };
 export const lineHeight = {
   tight: "125%",
   relaxed: "160%",
 };
 export const fontWeight = {
-  normal: 400,
-  bold: 700,
+  normal: "400",
+  bold: "700",
 };
 export const borderRadius = {
   base: 100,
@@ -56,5 +56,5 @@ export const themeDefaults = {
   fontWeight: fontWeight.normal,
   fontSize: fontSize.base,
   color: colors.black,
-  padding: 0,
+  padding: "0px",
 };

--- a/packages/cli/src/__mocks__/emails/AccountCreated.tsx
+++ b/packages/cli/src/__mocks__/emails/AccountCreated.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { MjmlSection, MjmlColumn, MjmlImage } from "mjml-react";
+import { MjmlSection, MjmlColumn, MjmlImage } from "@faire/mjml-react";
 import { Template } from "mailing-core";
 import Button from "./components/Button";
 import Header from "./components/Header";

--- a/packages/cli/src/__mocks__/emails/NewSignIn.tsx
+++ b/packages/cli/src/__mocks__/emails/NewSignIn.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from "react";
-import { MjmlSection, MjmlColumn, MjmlSpacer } from "mjml-react";
+import { MjmlSection, MjmlColumn, MjmlSpacer } from "@faire/mjml-react";
 import { Template } from "mailing-core";
 import Header from "./components/Header";
 import Heading from "./components/Heading";

--- a/packages/cli/src/__mocks__/emails/Reservation.tsx
+++ b/packages/cli/src/__mocks__/emails/Reservation.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from "react";
-import { MjmlSection, MjmlColumn } from "mjml-react";
+import { MjmlSection, MjmlColumn } from "@faire/mjml-react";
 import { Template } from "mailing-core";
 
 import Header from "./components/Header";

--- a/packages/cli/src/__mocks__/emails/ResetPassword.tsx
+++ b/packages/cli/src/__mocks__/emails/ResetPassword.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from "react";
-import { MjmlSection, MjmlColumn } from "mjml-react";
+import { MjmlSection, MjmlColumn } from "@faire/mjml-react";
 import { Template } from "mailing-core";
 
 import Header from "./components/Header";

--- a/packages/cli/src/__mocks__/emails/components/BaseLayout.tsx
+++ b/packages/cli/src/__mocks__/emails/components/BaseLayout.tsx
@@ -9,7 +9,7 @@ import {
   MjmlAll,
   MjmlRaw,
   MjmlPreview,
-} from "mjml-react";
+} from "@faire/mjml-react";
 import { colors, screens, themeDefaults, spacing } from "../theme";
 
 type BaseLayoutProps = {

--- a/packages/cli/src/__mocks__/emails/components/Button.tsx
+++ b/packages/cli/src/__mocks__/emails/components/Button.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { MjmlButton } from "mjml-react";
+import { MjmlButton } from "@faire/mjml-react";
 
 import { colors, fontSize, borderRadius, lineHeight, spacing } from "../theme";
 

--- a/packages/cli/src/__mocks__/emails/components/Divider.tsx
+++ b/packages/cli/src/__mocks__/emails/components/Divider.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { MjmlDivider } from "mjml-react";
+import { MjmlDivider } from "@faire/mjml-react";
 import { colors } from "../theme";
 
 type DividerProps = React.ComponentProps<typeof MjmlDivider>;

--- a/packages/cli/src/__mocks__/emails/components/Footer.tsx
+++ b/packages/cli/src/__mocks__/emails/components/Footer.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { MjmlSection, MjmlColumn, MjmlText } from "mjml-react";
+import { MjmlSection, MjmlColumn, MjmlText } from "@faire/mjml-react";
 import { EMAIL_PREFERENCES_URL } from "mailing-core";
 import { colors, fontSize, spacing } from "../theme";
 

--- a/packages/cli/src/__mocks__/emails/components/Header.tsx
+++ b/packages/cli/src/__mocks__/emails/components/Header.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { MjmlSection, MjmlColumn, MjmlImage } from "mjml-react";
+import { MjmlSection, MjmlColumn, MjmlImage } from "@faire/mjml-react";
 
 type HeaderProps = {
   loose?: boolean;

--- a/packages/cli/src/__mocks__/emails/components/List.tsx
+++ b/packages/cli/src/__mocks__/emails/components/List.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { MjmlRaw } from "mjml-react";
+import { MjmlRaw } from "@faire/mjml-react";
 
 import { themeDefaults } from "../theme";
 

--- a/packages/cli/src/__mocks__/emails/components/Text.tsx
+++ b/packages/cli/src/__mocks__/emails/components/Text.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { MjmlText } from "mjml-react";
+import { MjmlText } from "@faire/mjml-react";
 
 type TextProps = {
   maxWidth?: number;

--- a/packages/cli/src/__mocks__/emails/theme.ts
+++ b/packages/cli/src/__mocks__/emails/theme.ts
@@ -11,11 +11,11 @@ export const colors = {
 };
 
 export const fontSize = {
-  xs: 12,
-  sm: 14,
-  base: 16,
-  lg: 24,
-  xl: 30,
+  xs: "12px",
+  sm: "14px",
+  base: "16px",
+  lg: "24px",
+  xl: "30px",
 };
 
 export const lineHeight = {
@@ -24,8 +24,8 @@ export const lineHeight = {
 };
 
 export const fontWeight = {
-  normal: 400,
-  bold: 700,
+  normal: "400",
+  bold: "700",
 };
 
 export const borderRadius = {
@@ -64,5 +64,5 @@ export const themeDefaults = {
   fontWeight: fontWeight.normal,
   fontSize: fontSize.base,
   color: colors.black,
-  padding: 0,
+  padding: "0px",
 };

--- a/packages/cli/src/custom.d.ts
+++ b/packages/cli/src/custom.d.ts
@@ -43,3 +43,9 @@ type MailingConfig = {
   port?: number;
   quiet?: boolean;
 };
+
+type HrefProps = {
+	href?: string | undefined;
+	target?: string | undefined;
+	rel?: string | undefined;
+}

--- a/packages/cli/src/emails-js/Welcome.jsx
+++ b/packages/cli/src/emails-js/Welcome.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { MjmlColumn, MjmlSection, MjmlSpacer, MjmlWrapper } from "mjml-react";
+import { MjmlColumn, MjmlSection, MjmlSpacer, MjmlWrapper } from "@faire/mjml-react";
 import BaseLayout from "./components/BaseLayout";
 import Button from "./components/Button";
 import Footer from "./components/Footer";
@@ -32,8 +32,7 @@ const welcomeStyle = `
   }
 `;
 const Welcome = ({ includeUnsubscribe }) => {
-  return (
-    <BaseLayout width={600} style={welcomeStyle}>
+    return (<BaseLayout width={600} style={welcomeStyle}>
       <Header />
       <MjmlWrapper backgroundColor={colors.black}>
         <MjmlSection paddingBottom={spacing.s11} cssClass="gutter">
@@ -51,11 +50,7 @@ const Welcome = ({ includeUnsubscribe }) => {
               <span style={{ color: colors.green300 }}>●</span> This is the
               Preview Viewer
             </Heading>
-            <Text
-              cssClass="p"
-              fontSize={fontSize.md}
-              paddingBottom={spacing.s7}
-            >
+            <Text cssClass="p" fontSize={fontSize.md} paddingBottom={spacing.s7}>
               It shows previews from{" "}
               <span className="code">emails/previews</span>. Keep it open while
               you build your emails and it’ll live reload as you develop. To see
@@ -65,22 +60,12 @@ const Welcome = ({ includeUnsubscribe }) => {
               Preview Viewer with your team.
             </Text>
 
-            <Button
-              href="https://github.com/sofn-xyz/mailing-templates"
-              backgroundColor={colors.green300}
-              align="left"
-              cssClass="sm-hidden"
-            >
+            <Button href="https://github.com/sofn-xyz/mailing-templates" backgroundColor={colors.green300} align="left" cssClass="sm-hidden">
               More Demo Templates{"  "}
               <span style={{ fontFamily: fontFamily.serif }}>&rarr;</span>
             </Button>
-            <MjmlSpacer height={spacing.s3} cssClass="lg-hidden" />
-            <Button
-              href="https://github.com/sofn-xyz/mailing-templates"
-              backgroundColor={colors.green300}
-              align="right"
-              cssClass="lg-hidden"
-            >
+            <MjmlSpacer height={spacing.s3} cssClass="lg-hidden"/>
+            <Button href="https://github.com/sofn-xyz/mailing-templates" backgroundColor={colors.green300} align="right" cssClass="lg-hidden">
               More Demo Templates{"  "}
               <span style={{ fontFamily: fontFamily.serif }}>&rarr;</span>
             </Button>
@@ -98,32 +83,21 @@ const Welcome = ({ includeUnsubscribe }) => {
               they receive. When you try to send an email to an unsubscribed
               user, Mailing will intelligently block the send.
             </Text>
-            <Button
-              href="https://mailing.run/docs"
-              align="left"
-              backgroundColor={colors.blue}
-              cssClass="sm-hidden"
-            >
+            <Button href="https://mailing.run/docs" align="left" backgroundColor={colors.blue} cssClass="sm-hidden">
               Check out the Docs{"  "}
               <span style={{ fontFamily: fontFamily.serif }}>&rarr;</span>
             </Button>
-            <MjmlSpacer height={spacing.s3} cssClass="lg-hidden" />
-            <Button
-              href="https://mailing.run/docs"
-              align="right"
-              backgroundColor={colors.blue}
-              cssClass="lg-hidden"
-            >
+            <MjmlSpacer height={spacing.s3} cssClass="lg-hidden"/>
+            <Button href="https://mailing.run/docs" align="right" backgroundColor={colors.blue} cssClass="lg-hidden">
               Check out the Docs{"  "}
               <span style={{ fontFamily: fontFamily.serif }}>&rarr;</span>
             </Button>
-            <MjmlSpacer height={spacing.s9} />
+            <MjmlSpacer height={spacing.s9}/>
           </MjmlColumn>
         </MjmlSection>
       </MjmlWrapper>
-      <Footer includeUnsubscribe={includeUnsubscribe} />
-    </BaseLayout>
-  );
+      <Footer includeUnsubscribe={includeUnsubscribe}/>
+    </BaseLayout>);
 };
 Welcome.subject = "Thank you for installing Mailing :)";
 export default Welcome;

--- a/packages/cli/src/emails-js/components/BaseLayout.jsx
+++ b/packages/cli/src/emails-js/components/BaseLayout.jsx
@@ -1,33 +1,13 @@
 import React from "react";
-import {
-  Mjml,
-  MjmlBody,
-  MjmlHead,
-  MjmlFont,
-  MjmlStyle,
-  MjmlAttributes,
-  MjmlAll,
-} from "mjml-react";
-import {
-  screens,
-  themeDefaults,
-  spacing,
-  colors,
-  fontFamily,
-  fontSize,
-  borderRadius,
-} from "../theme";
+import { Mjml, MjmlBody, MjmlHead, MjmlFont, MjmlStyle, MjmlAttributes, MjmlAll, } from "@faire/mjml-react";
+import { screens, themeDefaults, spacing, colors, fontFamily, fontSize, borderRadius, } from "../theme";
 
-export default function BaseLayout({ width, children, style }) {
-  return (
-    <Mjml>
+export default function BaseLayout({ width, children, style, }) {
+    return (<Mjml>
       <MjmlHead>
-        <MjmlFont
-          name="neue-haas-unica"
-          href="https://use.typekit.net/qqd8jtb.css"
-        />
+        <MjmlFont name="neue-haas-unica" href="https://use.typekit.net/qqd8jtb.css"/>
         <MjmlAttributes>
-          <MjmlAll {...themeDefaults} />
+          <MjmlAll {...themeDefaults}/>
         </MjmlAttributes>
         <MjmlStyle>{`
           body {
@@ -96,6 +76,5 @@ export default function BaseLayout({ width, children, style }) {
       </MjmlHead>
 
       <MjmlBody width={width}>{children}</MjmlBody>
-    </Mjml>
-  );
+    </Mjml>);
 }

--- a/packages/cli/src/emails-js/components/Button.jsx
+++ b/packages/cli/src/emails-js/components/Button.jsx
@@ -1,29 +1,10 @@
 import React from "react";
 import cx from "classnames";
-import { MjmlButton } from "mjml-react";
-import {
-  colors,
-  fontSize,
-  borderRadius,
-  lineHeight,
-  fontWeight,
-} from "../theme";
+import { MjmlButton } from "@faire/mjml-react";
+import { colors, fontSize, borderRadius, lineHeight, fontWeight, } from "../theme";
 
 export default function Button(props) {
-  return (
-    <>
-      <MjmlButton
-        lineHeight={lineHeight.tight}
-        fontSize={fontSize.base}
-        fontWeight={fontWeight.bold}
-        innerPadding="16px 24px 18px"
-        align="left"
-        backgroundColor={colors.blue}
-        color={colors.black}
-        borderRadius={borderRadius.base}
-        cssClass={cx("button", props.cssClass)}
-        {...props}
-      />
-    </>
-  );
+    return (<>
+      <MjmlButton lineHeight={lineHeight.tight} fontSize={fontSize.base} fontWeight={fontWeight.bold} innerPadding="16px 24px 18px" align="left" backgroundColor={colors.blue} color={colors.black} borderRadius={borderRadius.base} cssClass={cx("button", props.cssClass)} {...props}/>
+    </>);
 }

--- a/packages/cli/src/emails-js/components/Footer.jsx
+++ b/packages/cli/src/emails-js/components/Footer.jsx
@@ -1,88 +1,40 @@
 import React from "react";
-import {
-  MjmlSection,
-  MjmlWrapper,
-  MjmlColumn,
-  MjmlText,
-  MjmlImage,
-  MjmlGroup,
-} from "mjml-react";
+import { MjmlSection, MjmlWrapper, MjmlColumn, MjmlText, MjmlImage, MjmlGroup, } from "@faire/mjml-react";
 import Link from "./Link";
 import { colors, fontSize, fontWeight } from "../theme";
 import { EMAIL_PREFERENCES_URL } from "mailing-core";
 
 export default function Footer({ includeUnsubscribe = false }) {
-  return (
-    <>
-      <MjmlWrapper
-        backgroundColor={colors.gray800}
-        borderBottom={`2px solid ${colors.black}`}
-      >
+    return (<>
+      <MjmlWrapper backgroundColor={colors.gray800} borderBottom={`2px solid ${colors.black}`}>
         <MjmlSection>
           <MjmlGroup>
-            <MjmlColumn
-              padding={"48px 0"}
-              borderRight={`2px solid ${colors.black}`}
-            >
-              <MjmlText
-                align="center"
-                fontSize={fontSize.xs}
-                color={colors.slate400}
-                fontWeight={fontWeight.bold}
-                paddingBottom={8}
-                textTransform="uppercase"
-              >
+            <MjmlColumn padding={"48px 0"} borderRight={`2px solid ${colors.black}`}>
+              <MjmlText align="center" fontSize={fontSize.xs} color={colors.slate400} fontWeight={fontWeight.bold} paddingBottom={8} textTransform="uppercase">
                 Help & Bugs
               </MjmlText>
               <MjmlText align="center">
-                <Link
-                  color={colors.white}
-                  fontSize={fontSize.sm}
-                  href="https://discord.gg/fdSzmY46wY"
-                >
-                  <img
-                    height={12}
-                    width={16}
-                    src={"https://mailing.run/welcome-template/discord.png"}
-                    alt=""
-                    style={{
-                      verticalAlign: "text-bottom",
-                      paddingRight: 6,
-                      paddingBottom: 4,
-                    }}
-                  />
+                <Link color={colors.white} fontSize={fontSize.sm} href="https://discord.gg/fdSzmY46wY">
+                  <img height={12} width={16} src={"https://mailing.run/welcome-template/discord.png"} alt="" style={{
+            verticalAlign: "text-bottom",
+            paddingRight: 6,
+            paddingBottom: 4,
+        }}/>
                   Discord
                 </Link>
               </MjmlText>
             </MjmlColumn>
             <MjmlColumn padding={"48px 0"}>
-              <MjmlText
-                align="center"
-                fontSize={fontSize.xs}
-                color={colors.slate400}
-                fontWeight={fontWeight.bold}
-                paddingBottom={8}
-                textTransform="uppercase"
-              >
+              <MjmlText align="center" fontSize={fontSize.xs} color={colors.slate400} fontWeight={fontWeight.bold} paddingBottom={8} textTransform="uppercase">
                 What we&rsquo;re up to
               </MjmlText>
               <MjmlText align="center">
-                <Link
-                  fontSize={fontSize.sm}
-                  color={colors.white}
-                  href="https://github.com/sofn-xyz/mailing/issues"
-                >
-                  <img
-                    height={16}
-                    width={16}
-                    src={"https://mailing.run/welcome-template/github.png"}
-                    alt=""
-                    style={{
-                      verticalAlign: "text-bottom",
-                      paddingRight: 6,
-                      paddingBottom: 2,
-                    }}
-                  />
+                <Link fontSize={fontSize.sm} color={colors.white} href="https://github.com/sofn-xyz/mailing/issues">
+                  <img height={16} width={16} src={"https://mailing.run/welcome-template/github.png"} alt="" style={{
+            verticalAlign: "text-bottom",
+            paddingRight: 6,
+            paddingBottom: 2,
+        }}/>
                   Issues
                 </Link>
               </MjmlText>
@@ -94,49 +46,26 @@ export default function Footer({ includeUnsubscribe = false }) {
       <MjmlWrapper backgroundColor={colors.gray800}>
         <MjmlSection paddingTop={32} paddingBottom={24} cssClass="gutter">
           <MjmlColumn>
-            <MjmlText
-              align="center"
-              fontSize={fontSize.xs}
-              color={colors.slate400}
-              fontWeight={fontWeight.bold}
-              textTransform="uppercase"
-            >
+            <MjmlText align="center" fontSize={fontSize.xs} color={colors.slate400} fontWeight={fontWeight.bold} textTransform="uppercase">
               Mailing {new Date().getFullYear()}
             </MjmlText>
 
-            {includeUnsubscribe && (
-              <MjmlText
-                align="center"
-                fontSize={fontSize.xs}
-                color={colors.slate400}
-                paddingTop={12}
-              >
+            {includeUnsubscribe && (<MjmlText align="center" fontSize={fontSize.xs} color={colors.slate400} paddingTop={12}>
                 You&rsquo;re receiving this email because you asked for
                 occasional updates about Mailing. If you don&rsquo;t want to
                 receive these in the future, you can{" "}
-                <Link
-                  color={colors.slate400}
-                  textDecoration="underline"
-                  href={EMAIL_PREFERENCES_URL}
-                >
+                <Link color={colors.slate400} textDecoration="underline" href={EMAIL_PREFERENCES_URL}>
                   unsubscribe.
                 </Link>
-              </MjmlText>
-            )}
+              </MjmlText>)}
           </MjmlColumn>
         </MjmlSection>
 
         <MjmlSection paddingBottom={40}>
           <MjmlColumn>
-            <MjmlImage
-              height={16}
-              width={13}
-              src={"https://mailing.run/welcome-template/logo.png"}
-              href="https://mailing.run"
-            />
+            <MjmlImage height={16} width={13} src={"https://mailing.run/welcome-template/logo.png"} href="https://mailing.run"/>
           </MjmlColumn>
         </MjmlSection>
       </MjmlWrapper>
-    </>
-  );
+    </>);
 }

--- a/packages/cli/src/emails-js/components/Header.jsx
+++ b/packages/cli/src/emails-js/components/Header.jsx
@@ -1,44 +1,26 @@
 import React from "react";
-import { MjmlColumn, MjmlGroup, MjmlSection, MjmlWrapper } from "mjml-react";
+import { MjmlColumn, MjmlGroup, MjmlSection, MjmlWrapper } from "@faire/mjml-react";
 import Text from "./Text";
 import Link from "./Link";
 import { colors, fontSize, lineHeight, fontWeight } from "../theme";
 
 export default function Header() {
-  return (
-    <MjmlWrapper padding="40px 0 64px" backgroundColor={colors.black}>
+    return (<MjmlWrapper padding="40px 0 64px" backgroundColor={colors.black}>
       <MjmlSection cssClass="gutter">
         <MjmlGroup>
           <MjmlColumn width="42%">
             <Text align="left">
-              <Link
-                color={colors.white}
-                fontSize={fontSize.xl}
-                fontWeight={fontWeight.bold}
-                href="https://mailing.run"
-                textDecoration="none"
-              >
-                <img
-                  height={24}
-                  width={112}
-                  src={"https://mailing.run/welcome-template/logo-full.png"}
-                  alt=""
-                  style={{
-                    verticalAlign: "text-bottom",
-                    paddingRight: 10,
-                    paddingBottom: 2,
-                  }}
-                />
+              <Link color={colors.white} fontSize={fontSize.xl} fontWeight={fontWeight.bold} href="https://mailing.run" textDecoration="none">
+                <img height={24} width={112} src={"https://mailing.run/welcome-template/logo-full.png"} alt="" style={{
+            verticalAlign: "text-bottom",
+            paddingRight: 10,
+            paddingBottom: 2,
+        }}/>
               </Link>
             </Text>
           </MjmlColumn>
           <MjmlColumn width="58%">
-            <Text
-              align="right"
-              fontSize={fontSize.xs}
-              lineHeight={lineHeight.tight}
-              fontWeight={fontWeight.bold}
-            >
+            <Text align="right" fontSize={fontSize.xs} lineHeight={lineHeight.tight} fontWeight={fontWeight.bold}>
               The open source email
               <br />
               platform for teams that code
@@ -46,6 +28,5 @@ export default function Header() {
           </MjmlColumn>
         </MjmlGroup>
       </MjmlSection>
-    </MjmlWrapper>
-  );
+    </MjmlWrapper>);
 }

--- a/packages/cli/src/emails-js/components/Text.jsx
+++ b/packages/cli/src/emails-js/components/Text.jsx
@@ -1,18 +1,15 @@
 import React from "react";
 import cx from "classnames";
-import { MjmlText } from "mjml-react";
+import { MjmlText } from "@faire/mjml-react";
 
 export default function Text({ children, maxWidth, ...props }) {
-  if (maxWidth) {
-    return (
-      <MjmlText {...props} cssClass={cx("button", props.cssClass)}>
+    if (maxWidth) {
+        return (<MjmlText {...props} cssClass={cx("button", props.cssClass)}>
         <div style={{ maxWidth }}>{children}</div>
-      </MjmlText>
-    );
-  } else
-    return (
-      <MjmlText {...props} cssClass={cx("button", props.cssClass)}>
+      </MjmlText>);
+    }
+    else
+        return (<MjmlText {...props} cssClass={cx("button", props.cssClass)}>
         {children}
-      </MjmlText>
-    );
+      </MjmlText>);
 }

--- a/packages/cli/src/emails-js/theme.js
+++ b/packages/cli/src/emails-js/theme.js
@@ -26,13 +26,13 @@ export const colors = {
   zinc800: "#27272a",
 };
 export const fontSize = {
-  xs: 12,
-  sm: 14,
-  base: 16,
-  md: 18,
-  lg: 20,
-  xl: 24,
-  xxl: 28,
+  xs: "12px",
+  sm: "14px",
+  base: "16px",
+  md: "18px",
+  lg: "20px",
+  xl: "24px",
+  xxl: "28px",
 };
 export const lineHeight = {
   tight: "115%",
@@ -40,8 +40,8 @@ export const lineHeight = {
   relaxed: "185%",
 };
 export const fontWeight = {
-  normal: 400,
-  bold: 700,
+  normal: "400",
+  bold: "700",
 };
 export const borderRadius = {
   sm: 8,
@@ -77,5 +77,5 @@ export const themeDefaults = {
   fontWeight: fontWeight.normal,
   fontSize: fontSize.base,
   color: colors.white,
-  padding: 0,
+  padding: "0px",
 };

--- a/packages/cli/src/emails/Welcome.tsx
+++ b/packages/cli/src/emails/Welcome.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { MjmlColumn, MjmlSection, MjmlSpacer, MjmlWrapper } from "mjml-react";
+import { MjmlColumn, MjmlSection, MjmlSpacer, MjmlWrapper } from "@faire/mjml-react";
 import BaseLayout from "./components/BaseLayout";
 import Button from "./components/Button";
 import Footer from "./components/Footer";

--- a/packages/cli/src/emails/components/BaseLayout.tsx
+++ b/packages/cli/src/emails/components/BaseLayout.tsx
@@ -7,7 +7,7 @@ import {
   MjmlStyle,
   MjmlAttributes,
   MjmlAll,
-} from "mjml-react";
+} from "@faire/mjml-react";
 import {
   screens,
   themeDefaults,

--- a/packages/cli/src/emails/components/Button.tsx
+++ b/packages/cli/src/emails/components/Button.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import cx from "classnames";
-import { MjmlButton } from "mjml-react";
+import { MjmlButton } from "@faire/mjml-react";
 
 import {
   colors,

--- a/packages/cli/src/emails/components/Footer.tsx
+++ b/packages/cli/src/emails/components/Footer.tsx
@@ -6,7 +6,7 @@ import {
   MjmlText,
   MjmlImage,
   MjmlGroup,
-} from "mjml-react";
+} from "@faire/mjml-react";
 import Link from "./Link";
 import { colors, fontSize, fontWeight } from "../theme";
 import { EMAIL_PREFERENCES_URL } from "mailing-core";

--- a/packages/cli/src/emails/components/Header.tsx
+++ b/packages/cli/src/emails/components/Header.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { MjmlColumn, MjmlGroup, MjmlSection, MjmlWrapper } from "mjml-react";
+import { MjmlColumn, MjmlGroup, MjmlSection, MjmlWrapper } from "@faire/mjml-react";
 import Text from "./Text";
 import Link from "./Link";
 import { colors, fontSize, lineHeight, fontWeight } from "../theme";

--- a/packages/cli/src/emails/components/Link.tsx
+++ b/packages/cli/src/emails/components/Link.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { MjmlText, HrefProps } from "mjml-react";
+import { MjmlText } from "@faire/mjml-react";
 import { colors } from "../theme";
 
 type LinkProps = HrefProps & React.ComponentProps<typeof MjmlText>;

--- a/packages/cli/src/emails/components/Text.tsx
+++ b/packages/cli/src/emails/components/Text.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import cx from "classnames";
-import { MjmlText } from "mjml-react";
+import { MjmlText } from "@faire/mjml-react";
 
 type TextProps = {
   maxWidth?: number;

--- a/packages/cli/src/emails/theme.ts
+++ b/packages/cli/src/emails/theme.ts
@@ -27,13 +27,13 @@ export const colors = {
 };
 
 export const fontSize = {
-  xs: 12,
-  sm: 14,
-  base: 16,
-  md: 18,
-  lg: 20,
-  xl: 24,
-  xxl: 28,
+  xs: "12px",
+  sm: "14px",
+  base: "16px",
+  md: "18px",
+  lg: "20px",
+  xl: "24px",
+  xxl: "28px",
 };
 
 export const lineHeight = {
@@ -43,8 +43,8 @@ export const lineHeight = {
 };
 
 export const fontWeight = {
-  normal: 400,
-  bold: 700,
+  normal: "400",
+  bold: "700",
 };
 
 export const borderRadius = {
@@ -85,5 +85,5 @@ export const themeDefaults = {
   fontWeight: fontWeight.normal,
   fontSize: fontSize.base,
   color: colors.white,
-  padding: 0,
+  padding: "0px",
 };

--- a/packages/cli/src/pages/api/render.ts
+++ b/packages/cli/src/pages/api/render.ts
@@ -1,5 +1,4 @@
 import type { NextApiRequest, NextApiResponse } from "next";
-import { MjmlError } from "mjml-react";
 
 import renderTemplate from "../../util/renderTemplate";
 import { validateApiKey } from "../../util/validate/validateApiKey";

--- a/packages/cli/src/pages/api/sendMail.ts
+++ b/packages/cli/src/pages/api/sendMail.ts
@@ -1,5 +1,4 @@
 import type { NextApiRequest, NextApiResponse } from "next";
-import { MjmlError } from "mjml-react";
 import { sendMail } from "../../moduleManifest";
 import { validateApiKey } from "../../util/validate/validateApiKey";
 import { createElement } from "react";

--- a/packages/cli/src/util/__test__/mjml.test.tsx
+++ b/packages/cli/src/util/__test__/mjml.test.tsx
@@ -5,7 +5,7 @@ import {
   MjmlColumn,
   MjmlImage,
   MjmlSection,
-} from "mjml-react";
+} from "@faire/mjml-react";
 import { render } from "../mjml";
 
 describe("mjml", () => {

--- a/packages/cli/src/util/mjml.ts
+++ b/packages/cli/src/util/mjml.ts
@@ -1,5 +1,6 @@
 import { JSXElementConstructor, ReactElement } from "react";
-import { render as mjRender } from "mjml-react";
+import { renderToMjml } from "@faire/mjml-react/utils/renderToMjml";
+import mjml2html from "mjml";
 import { parse } from "node-html-parser";
 
 function lintHtml(html: string) {
@@ -45,7 +46,7 @@ function lintHtml(html: string) {
 export function render(
   component: ReactElement<any, string | JSXElementConstructor<any>>
 ) {
-  const { html, errors } = mjRender(component);
+  const { html, errors } = mjml2html(renderToMjml(component));
   const htmlLint = lintHtml(html);
   return { html, errors, htmlLint };
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,10 +10,10 @@
     "url": "git+https://github.com/sofn-xyz/mailing.git"
   },
   "dependencies": {
+    "@faire/mjml-react": "^3.1.2",
     "chalk": "^4.1.2",
     "fs-extra": "^10.1.0",
     "mjml": "^4.12.0",
-    "mjml-react": "^2.0.7",
     "node-fetch": "^2.6.7",
     "node-html-parser": "^6.1.1",
     "open": "^8.4.0",

--- a/packages/core/src/__test__/index.test.tsx
+++ b/packages/core/src/__test__/index.test.tsx
@@ -7,7 +7,7 @@ import {
   ComponentMail,
   BuildSendMailOptions,
 } from "..";
-import { Mjml, MjmlBody, MjmlRaw } from "mjml-react";
+import { Mjml, MjmlBody, MjmlRaw } from "@faire/mjml-react";
 import fetch from "node-fetch";
 import open from "open";
 import * as postHog from "../util/postHog";

--- a/packages/core/src/__test__/render.test.tsx
+++ b/packages/core/src/__test__/render.test.tsx
@@ -1,5 +1,5 @@
 import { render } from "../index";
-import { Mjml, MjmlBody, MjmlRaw } from "mjml-react";
+import { Mjml, MjmlBody, MjmlRaw } from "@faire/mjml-react";
 
 describe("index render", () => {
   it("takes an MJML react component and renders HTML", () => {

--- a/packages/core/src/mjml.ts
+++ b/packages/core/src/mjml.ts
@@ -1,11 +1,11 @@
 import { JSXElementConstructor, ReactElement } from "react";
-import { render as mjRender } from "mjml-react";
+import { renderToMjml } from "@faire/mjml-react/utils/renderToMjml";
+import mjml2html from "mjml";
 
 export function render(
   component: ReactElement<any, string | JSXElementConstructor<any>>
 ) {
-  return mjRender(component, {
+  return mjml2html(renderToMjml(component), {
     validationLevel: "soft",
-    minify: undefined,
   });
 }

--- a/packages/web/emails/Newsletter.tsx
+++ b/packages/web/emails/Newsletter.tsx
@@ -1,4 +1,4 @@
-import { MjmlSection, MjmlColumn, MjmlImage, MjmlWrapper } from "mjml-react";
+import { MjmlSection, MjmlColumn, MjmlImage, MjmlWrapper } from "@faire/mjml-react";
 import Layout from "./components/Layout";
 import Footer from "./components/Footer";
 import Heading from "./components/Heading";

--- a/packages/web/emails/components/Button.tsx
+++ b/packages/web/emails/components/Button.tsx
@@ -1,4 +1,4 @@
-import { MjmlButton } from "mjml-react";
+import { MjmlButton } from "@faire/mjml-react";
 
 import {
   colors,

--- a/packages/web/emails/components/Footer.tsx
+++ b/packages/web/emails/components/Footer.tsx
@@ -5,7 +5,7 @@ import {
   MjmlText,
   MjmlImage,
   MjmlGroup,
-} from "mjml-react";
+} from "@faire/mjml-react";
 import Link from "./Link";
 import { colors, fontSize, fontWeight } from "../theme";
 import assetUrl from "../util/assetUrl";

--- a/packages/web/emails/components/Header.tsx
+++ b/packages/web/emails/components/Header.tsx
@@ -4,7 +4,7 @@ import {
   MjmlImage,
   MjmlSection,
   MjmlWrapper,
-} from "mjml-react";
+} from "@faire/mjml-react";
 import { colors } from "../theme";
 import assetUrl from "../util/assetUrl";
 

--- a/packages/web/emails/components/Layout.tsx
+++ b/packages/web/emails/components/Layout.tsx
@@ -6,7 +6,7 @@ import {
   MjmlStyle,
   MjmlAttributes,
   MjmlAll,
-} from "mjml-react";
+} from "@faire/mjml-react";
 import { colors, spacing, screens, themeDefaults } from "../theme";
 import cssHelpers from "../util/cssHelpers";
 

--- a/packages/web/emails/components/Link.tsx
+++ b/packages/web/emails/components/Link.tsx
@@ -1,5 +1,11 @@
-import { MjmlText, HrefProps } from "mjml-react";
+import { MjmlText } from "@faire/mjml-react";
 import { colors } from "../theme";
+
+type HrefProps = {
+	href?: string | undefined;
+	target?: string | undefined;
+	rel?: string | undefined;
+}
 
 type LinkProps = HrefProps & React.ComponentProps<typeof MjmlText>;
 type StyleProps = Pick<

--- a/packages/web/emails/components/List.tsx
+++ b/packages/web/emails/components/List.tsx
@@ -1,4 +1,4 @@
-import { MjmlRaw } from "mjml-react";
+import { MjmlRaw } from "@faire/mjml-react";
 
 import { fontSize, themeDefaults } from "../theme";
 

--- a/packages/web/emails/components/Spacer.tsx
+++ b/packages/web/emails/components/Spacer.tsx
@@ -1,4 +1,4 @@
-import { MjmlSpacer } from "mjml-react";
+import { MjmlSpacer } from "@faire/mjml-react";
 
 type SpacerProps = {
   sm?: React.ComponentProps<typeof MjmlSpacer>;

--- a/packages/web/emails/components/Text.tsx
+++ b/packages/web/emails/components/Text.tsx
@@ -1,4 +1,4 @@
-import { MjmlText } from "mjml-react";
+import { MjmlText } from "@faire/mjml-react";
 
 type TextProps = {
   maxWidth?: number;

--- a/packages/web/emails/theme.ts
+++ b/packages/web/emails/theme.ts
@@ -27,16 +27,16 @@ export const colors = {
 };
 
 export const fontSize = {
-  xs: 12,
-  sm: 14,
-  base: 16,
-  lg: 20,
-  xl: 30,
+  xs: "12px",
+  sm: "14px",
+  base: "16px",
+  lg: "20px",
+  xl: "30px",
 };
 
 export const fontWeight = {
-  normal: 400,
-  bold: 700,
+  normal: "400",
+  bold: "700",
 };
 
 export const lineHeight = {
@@ -72,5 +72,5 @@ export const themeDefaults = {
   fontWeight: fontWeight.normal,
   fontSize: fontSize.base,
   color: colors.white,
-  padding: 0,
+  padding: "0px",
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1434,6 +1434,13 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
+"@faire/mjml-react@^3.1.2":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@faire/mjml-react/-/mjml-react-3.1.2.tgz#68360585de138a18e370f30795597e68af3b244b"
+  integrity sha512-VNSZ1B/Qd4t2jtDxOHggdbJwBk4gISCa8xUdiguYNgzhWvg0ltMOVJih/7qVwbNfOB77X4jQamjTMMokCtKYfw==
+  dependencies:
+    lodash.kebabcase "^4.1.1"
+
 "@hapi/hoek@^9.0.0":
   version "9.3.0"
   resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.3.0.tgz#8368869dcb735be2e7f5cb7647de78e167a251fb"
@@ -2513,13 +2520,6 @@
   resolved "https://registry.yarnpkg.com/@types/mjml-core/-/mjml-core-4.7.1.tgz#c2627499045b54eccfca38e2b532566fb0689189"
   integrity sha512-k5IRafi93tyZBGF+0BTrcBDvG47OueI+Q7TC4V4UjGQn0AMVvL3Y+S26QF/UHMmMJW5r1hxLyv3StX2/+FatFg==
 
-"@types/mjml-react@^2.0.4":
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/@types/mjml-react/-/mjml-react-2.0.6.tgz#f63f6af88e89fb588099bb3dd1f487befdb1a061"
-  integrity sha512-pOYAX16xjkWNHWPNETfDYiUGYYwHQeuhtrUFDVCWh49zisgkLRG9kA3W9324Kc+KmO+xQp2LQldTVprhJ7ZMbw==
-  dependencies:
-    "@types/react" "*"
-
 "@types/mjml@^4.7.0":
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/@types/mjml/-/mjml-4.7.0.tgz#ea31b58008f54119efda9e673af674757d35981b"
@@ -3290,14 +3290,6 @@ babel-preset-jest@^29.2.0:
     babel-plugin-jest-hoist "^29.2.0"
     babel-preset-current-node-syntax "^1.0.0"
 
-babel-runtime@~6.25.0:
-  version "6.25.0"
-  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.25.0.tgz#33b98eaa5d482bb01a8d1aa6b437ad2b01aec41c"
-  integrity sha512-zeCYxDePWYAT/DfmQWIHsMSFW2vv45UIwIAMjGvQVsTd47RwsiRH0uK1yzyWZ7LDBKdhnGDPM6NYEO5CZyhPrg==
-  dependencies:
-    core-js "^2.4.0"
-    regenerator-runtime "^0.10.0"
-
 bail@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/bail/-/bail-2.0.2.tgz#d26f5cd8fe5d6f832a31517b9f7c356040ba6d5d"
@@ -3799,7 +3791,7 @@ collect-v8-coverage@^1.0.0:
   resolved "https://registry.yarnpkg.com/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz#cc2c8e94fc18bbdffe64d6534570c8a673b27f59"
   integrity sha512-iBPtljfCNcTKNAto0KEtDfZ3qzjJvqE3aTGZsbhjSBlorqpXJlaWWtPO35D+ZImoC3KWejX64o+yPGxhWSTzfg==
 
-color-convert@^1.9.0, color-convert@^1.9.3:
+color-convert@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
   integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
@@ -3818,31 +3810,15 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
 
-color-name@^1.0.0, color-name@^1.1.4, color-name@~1.1.4:
+color-name@^1.1.4, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
-
-color-string@^1.6.0:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.9.1.tgz#4467f9146f036f855b764dfb5bf8582bf342c7a4"
-  integrity sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==
-  dependencies:
-    color-name "^1.0.0"
-    simple-swizzle "^0.2.2"
 
 color-support@^1.1.2:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-support/-/color-support-1.1.3.tgz#93834379a1cc9a0c61f82f52f0d04322251bd5a2"
   integrity sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==
-
-color@^3.1.3:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/color/-/color-3.2.1.tgz#3544dc198caf4490c3ecc9a790b54fe9ff45e164"
-  integrity sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==
-  dependencies:
-    color-convert "^1.9.3"
-    color-string "^1.6.0"
 
 colorette@^2.0.16, colorette@^2.0.17:
   version "2.0.19"
@@ -3937,11 +3913,6 @@ core-js-pure@^3.25.1:
   version "3.25.5"
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.25.5.tgz#79716ba54240c6aa9ceba6eee08cf79471ba184d"
   integrity sha512-oml3M22pHM+igfWHDfdLVq2ShWmjM2V4L+dQEBs0DWVIqEm9WHCwGAlZ6BmyBQGy5sFrJmcx+856D9lVKyGWYg==
-
-core-js@^2.4.0:
-  version "2.6.12"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
-  integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
 
 core-util-is@1.0.2:
   version "1.0.2"
@@ -6017,11 +5988,6 @@ is-arrayish@^0.2.1:
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==
 
-is-arrayish@^0.3.1:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.2.tgz#4574a2ae56f7ab206896fb431eaeed066fdf8f03"
-  integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
-
 is-bigint@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-bigint/-/is-bigint-1.0.4.tgz#08147a1875bc2b32005d41ccd8291dffc6691df3"
@@ -7104,6 +7070,11 @@ lodash.isplainobject@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
   integrity sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==
+
+lodash.kebabcase@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz#8489b1cb0d29ff88195cceca448ff6d6cc295c36"
+  integrity sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==
 
 lodash.memoize@4.x:
   version "4.1.2"
@@ -8206,16 +8177,6 @@ mjml-raw@4.13.0:
     lodash "^4.17.21"
     mjml-core "4.13.0"
 
-mjml-react@^2.0.7:
-  version "2.0.8"
-  resolved "https://registry.yarnpkg.com/mjml-react/-/mjml-react-2.0.8.tgz#3100e5aad9e8be110c6ba3c9ccea24a1d871eb4d"
-  integrity sha512-3wtHZZs1Y7e7Tl+ImojD/+aPE8Z0xshMww7MKSQlD9A1E/92amWQilGZN3T+WjWWaDueKcH2Gc1RJ72PLGSRGA==
-  dependencies:
-    "@babel/runtime" "^7.14.6"
-    babel-runtime "~6.25.0"
-    color "^3.1.3"
-    react-reconciler "^0.26.1"
-
 mjml-section@4.13.0:
   version "4.13.0"
   resolved "https://registry.yarnpkg.com/mjml-section/-/mjml-section-4.13.0.tgz#ce742b4b4d2a1921bee36dbe735e9a6471cb6dd1"
@@ -9201,15 +9162,6 @@ react-is@^18.0.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
-react-reconciler@^0.26.1:
-  version "0.26.2"
-  resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.26.2.tgz#bbad0e2d1309423f76cf3c3309ac6c96e05e9d91"
-  integrity sha512-nK6kgY28HwrMNwDnMui3dvm3rCFjZrcGiuwLc5COUipBK5hWHLOxMJhSnSomirqWwjPBJKV1QcbkI0VJr7Gl1Q==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    scheduler "^0.20.2"
-
 react-tiny-popover@^7.1.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/react-tiny-popover/-/react-tiny-popover-7.1.0.tgz#809bffefd54c7921eba96991f964953858e3388f"
@@ -9306,11 +9258,6 @@ regenerate@^1.4.2:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.2.tgz#b9346d8827e8f5a32f7ba29637d398b69014848a"
   integrity sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==
-
-regenerator-runtime@^0.10.0:
-  version "0.10.5"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
-  integrity sha512-02YopEIhAgiBHWeoTiA8aitHDt8z6w+rQqNuIftlM+ZtvSl/brTouaU7DW6GO/cHtvxJvS4Hwv2ibKdxIRi24w==
 
 regenerator-runtime@^0.13.10:
   version "0.13.10"
@@ -9580,14 +9527,6 @@ saxes@^6.0.0:
   dependencies:
     xmlchars "^2.2.0"
 
-scheduler@^0.20.2:
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.2.tgz#4baee39436e34aa93b4874bddcbf0fe8b8b50e91"
-  integrity sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-
 scheduler@^0.23.0:
   version "0.23.0"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.0.tgz#ba8041afc3d30eb206a487b6b384002e4e61fdfe"
@@ -9676,13 +9615,6 @@ signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.7:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
-
-simple-swizzle@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
-  integrity sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==
-  dependencies:
-    is-arrayish "^0.3.1"
 
 sisteransi@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
## Describe your changes
A third attempt at #222 and #224

I ran into some types issues where `@faire/mjml-react` was less permissive with props like `padding`, `fontWeight` or `fontSize` so I converted values where needed (e.g. `padding: 0` => `padding: "0px"`). There is a discussion about this in https://github.com/Faire/mjml-react/pull/81

## Issue link
#203 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
