### PR TITLE
Framework test improvements and bump node

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,7 +12,8 @@ jobs:
       fail-fast: false
       matrix:
         e2e-config:
-          - standalone
+          - standalone_js
+          - standalone_ts
           # - turbo
           - next_js
           - next_ts

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-nodejs 16.18.0
+nodejs 16.19.0
 yarn 1.22.19
 ruby 3.1.2

--- a/e2e/app.rb
+++ b/e2e/app.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-require_relative 'app/standalone'
+require_relative 'app/standalone_js'
+require_relative 'app/standalone_ts'
 require_relative 'app/turbo'
 require_relative 'app/next_ts'
 require_relative 'app/next_js'
@@ -14,7 +15,8 @@ module App
   attr_reader :typescript
 
   CONFIGS = {
-    standalone: App::Standalone,
+    standalone_js: App::StandaloneJs,
+    standalone_ts: App::StandaloneTs,
     turbo: App::Turbo,
     next_ts: App::NextTs,
     next_js: App::NextJs,

--- a/e2e/app/base.rb
+++ b/e2e/app/base.rb
@@ -32,6 +32,7 @@ module App
 
         if @save_cache
           verify_package_json_exists!
+          verify_tsconfig_json_exists!
           FileUtils.cp_r(@root_dir, File.join(Config::CACHE_DIR, @name))
         end
       end
@@ -44,6 +45,7 @@ module App
       use_cache do
         yarn_create!
         verify_package_json_exists!
+        verify_tsconfig_json_exists!
         yarn_add_test_dependencies!
         add_yarn_ci_scripts!
       end
@@ -52,7 +54,7 @@ module App
       yarn!
       copy_ci_scripts!
       intialize_mailing!
-      verify_typescript!
+      verify_typescript_mailing_config!
     end
 
     def run_mailing
@@ -89,7 +91,11 @@ module App
       raise "missing package.json in #{root_dir}" unless File.exist?(File.join(root_dir, 'package.json'))
     end
 
-    def verify_typescript!
+    def verify_tsconfig_json_exists!
+      raise "missing tsconfig.json in #{root_dir}" if @typescript && !File.exist?(File.join(root_dir, 'tsconfig.json'))
+    end
+
+    def verify_typescript_mailing_config!
       return unless @typescript
 
       mailing_config_json = File.join(root_dir, 'mailing.config.json')

--- a/e2e/app/base.rb
+++ b/e2e/app/base.rb
@@ -14,6 +14,7 @@ module App
 
     def initialize(name, root_dir, opts)
       @name = name
+      @tsconfig_path ||= 'tsconfig.json'
       @root_dir = root_dir
       @save_cache = opts[:save_cache]
     end
@@ -92,7 +93,8 @@ module App
     end
 
     def verify_tsconfig_json_exists!
-      raise "missing tsconfig.json in #{root_dir}" if @typescript && !File.exist?(File.join(root_dir, 'tsconfig.json'))
+      raise "missing #{@tsconfig_path} in #{root_dir}" if @typescript && !File.exist?(File.join(root_dir,
+                                                                                                @tsconfig_path))
     end
 
     def verify_typescript_mailing_config!

--- a/e2e/app/next_js.rb
+++ b/e2e/app/next_js.rb
@@ -12,8 +12,11 @@ module App
 
     def yarn_create!
       Dir.chdir(root_dir) do
-        cmd = 'yarn create next-app . --javascript'
-        cmd += "--no-eslint --no-src-dir --no-experimental-app --import-alias='@/*'"
+        cmd = <<-STR.split("\n").map(&:strip).join(' ')
+          yarn create next-app .
+          --javascript
+          --no-eslint --no-src-dir --no-experimental-app --import-alias='@/*'
+        STR
         system_quiet(cmd)
       end
     end

--- a/e2e/app/next_js.rb
+++ b/e2e/app/next_js.rb
@@ -12,7 +12,9 @@ module App
 
     def yarn_create!
       Dir.chdir(root_dir) do
-        system_quiet('yarn create next-app . --javascript --no-eslint')
+        cmd = 'yarn create next-app . --javascript'
+        cmd += "--no-eslint --no-src-dir --no-experimental-app --import-alias='@/*'"
+        system_quiet(cmd)
       end
     end
   end

--- a/e2e/app/next_ts.rb
+++ b/e2e/app/next_ts.rb
@@ -13,8 +13,11 @@ module App
 
     def yarn_create!
       Dir.chdir(root_dir) do
-        cmd = 'yarn create next-app . --typescript'
-        cmd += "--no-eslint --no-src-dir --no-experimental-app --import-alias='@/*'"
+        cmd = <<-STR.split("\n").map(&:strip).join(' ')
+          yarn create next-app .
+          --typescript
+          --no-eslint --no-src-dir --no-experimental-app --import-alias='@/*'
+        STR
         system_quiet(cmd)
       end
     end

--- a/e2e/app/next_ts.rb
+++ b/e2e/app/next_ts.rb
@@ -13,7 +13,9 @@ module App
 
     def yarn_create!
       Dir.chdir(root_dir) do
-        system_quiet('yarn create next-app . --typescript --no-eslint')
+        cmd = 'yarn create next-app . --typescript'
+        cmd += "--no-eslint --no-src-dir --no-experimental-app --import-alias='@/*'"
+        system_quiet(cmd)
       end
     end
   end

--- a/e2e/app/redwood_js.rb
+++ b/e2e/app/redwood_js.rb
@@ -12,7 +12,7 @@ module App
 
     def yarn_create!
       Dir.chdir(root_dir) do
-        system_quiet('yarn create redwood-app . --ts=false')
+        system_quiet('yarn create redwood-app . --ts=false --no-git')
 
         # yarn add peer dependencies
         system_quiet('yarn add next react react-dom')

--- a/e2e/app/redwood_ts.rb
+++ b/e2e/app/redwood_ts.rb
@@ -13,7 +13,7 @@ module App
 
     def yarn_create!
       Dir.chdir(root_dir) do
-        system_quiet('yarn create redwood-app . --typescript')
+        system_quiet('yarn create redwood-app . --typescript --no-git')
 
         # yarn add peer dependencies
         system_quiet('yarn add next react react-dom')

--- a/e2e/app/redwood_ts.rb
+++ b/e2e/app/redwood_ts.rb
@@ -6,6 +6,7 @@ module App
   class RedwoodTs < Base
     def initialize(root_dir, *args)
       @typescript = true
+      @tsconfig_path = 'web/tsconfig.json'
       super('redwood_ts', root_dir, *args)
     end
 

--- a/e2e/app/standalone_js.rb
+++ b/e2e/app/standalone_js.rb
@@ -3,7 +3,7 @@
 require_relative 'base'
 
 module App
-  class Standalone < Base
+  class StandaloneJs < Base
     def initialize(root_dir, *args)
       super('standalone', root_dir, *args)
     end

--- a/e2e/app/standalone_js.rb
+++ b/e2e/app/standalone_js.rb
@@ -5,7 +5,7 @@ require_relative 'base'
 module App
   class StandaloneJs < Base
     def initialize(root_dir, *args)
-      super('standalone', root_dir, *args)
+      super('standalone_js', root_dir, *args)
     end
 
     private

--- a/e2e/app/standalone_ts.rb
+++ b/e2e/app/standalone_ts.rb
@@ -14,7 +14,7 @@ module App
     def yarn_create!
       Dir.chdir(root_dir) do
         system_quiet('yarn init --yes')
-        system_quiet('yarn add typescript && yarn tsc --init')
+        system_quiet('yarn add typescript && yarn tsc --init --jsx=preserve')
 
         # yarn add peer dependencies
         system_quiet('yarn add next react react-dom')

--- a/e2e/app/standalone_ts.rb
+++ b/e2e/app/standalone_ts.rb
@@ -14,7 +14,7 @@ module App
     def yarn_create!
       Dir.chdir(root_dir) do
         system_quiet('yarn init --yes')
-        system_quiet('yarn add typescript && yarn tsc --init --jsx=preserve')
+        system_quiet('yarn add typescript && yarn tsc --init')
 
         # yarn add peer dependencies
         system_quiet('yarn add next react react-dom')

--- a/e2e/app/standalone_ts.rb
+++ b/e2e/app/standalone_ts.rb
@@ -14,7 +14,7 @@ module App
     def yarn_create!
       Dir.chdir(root_dir) do
         system_quiet('yarn init --yes')
-        system_quiet('yarn tsc --init')
+        system_quiet('yarn add typescript && yarn tsc --init')
 
         # yarn add peer dependencies
         system_quiet('yarn add next react react-dom')

--- a/e2e/app/standalone_ts.rb
+++ b/e2e/app/standalone_ts.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module App
+  class StandaloneTs < Base
+    def initialize(root_dir, *args)
+      super('standalone', root_dir, *args)
+    end
+
+    private
+
+    def yarn_create!
+      Dir.chdir(root_dir) do
+        system_quiet('yarn init --yes')
+        system_quiet('npx tsc init --yes')
+
+        # yarn add peer dependencies
+        system_quiet('yarn add next react react-dom')
+      end
+    end
+  end
+end

--- a/e2e/app/standalone_ts.rb
+++ b/e2e/app/standalone_ts.rb
@@ -5,7 +5,8 @@ require_relative 'base'
 module App
   class StandaloneTs < Base
     def initialize(root_dir, *args)
-      super('standalone', root_dir, *args)
+      @typescript = true
+      super('standalone_ts', root_dir, *args)
     end
 
     private

--- a/e2e/app/standalone_ts.rb
+++ b/e2e/app/standalone_ts.rb
@@ -13,7 +13,7 @@ module App
     def yarn_create!
       Dir.chdir(root_dir) do
         system_quiet('yarn init --yes')
-        system_quiet('npx tsc init --yes')
+        system_quiet('yarn tsc --init')
 
         # yarn add peer dependencies
         system_quiet('yarn add next react react-dom')


### PR DESCRIPTION
- bump node 16.18.0 -> 16.19.0 because latest create-redwood-app requires 16.19.0 at minimum

Framework test bumps:
- update create-next-app defaults so that the user is not prompted for more info
- update create-redwood-app defaults so that the user is not prompted for more info
- split standalone into js and ts (will help to debug @faire/mjml-react branch)