### PR TITLE
Pass minifier callback to mjml-react render method

### DIFF
--- a/.changeset/afraid-emus-try.md
+++ b/.changeset/afraid-emus-try.md
@@ -1,0 +1,7 @@
+---
+"mailing-core": patch
+"web": patch
+"mailing": patch
+---
+
+add processHtml option for minification etc after mjml is converted to html

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -27,7 +27,7 @@ export type BuildSendMailOptions<T> = {
   transport: Transporter<T>;
   defaultFrom: string;
   configPath: string;
-  minifyCb?: (html: string) => string;
+  processHtml?: (html: string) => string;
 };
 
 export type ComponentMail = SendMailOptions & {
@@ -117,7 +117,7 @@ export function buildSendMail<T>(options: BuildSendMailOptions<T>) {
     if (component && !mailOptions.html) {
       const { html: renderedHtml, errors } = render(
         component,
-        options.minifyCb
+        options.processHtml
       );
       if (errors?.length) {
         error(errors);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -115,10 +115,9 @@ export function buildSendMail<T>(options: BuildSendMailOptions<T>) {
     // Get html from the rendered component if not provided
     let derivedTemplateName;
     if (component && !mailOptions.html) {
-      const { html: renderedHtml, errors } = render(
-        component,
-        options.processHtml
-      );
+      const { html: renderedHtml, errors } = render(component, {
+        processHtml: options.processHtml,
+      });
       if (errors?.length) {
         error(errors);
         throw new MalformedInputError(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -27,6 +27,7 @@ export type BuildSendMailOptions<T> = {
   transport: Transporter<T>;
   defaultFrom: string;
   configPath: string;
+  minifyCb?: (html: string) => string;
 };
 
 export type ComponentMail = SendMailOptions & {
@@ -114,7 +115,10 @@ export function buildSendMail<T>(options: BuildSendMailOptions<T>) {
     // Get html from the rendered component if not provided
     let derivedTemplateName;
     if (component && !mailOptions.html) {
-      const { html: renderedHtml, errors } = render(component);
+      const { html: renderedHtml, errors } = render(
+        component,
+        options.minifyCb
+      );
       if (errors?.length) {
         error(errors);
         throw new MalformedInputError(

--- a/packages/core/src/mjml.ts
+++ b/packages/core/src/mjml.ts
@@ -2,10 +2,16 @@ import { JSXElementConstructor, ReactElement } from "react";
 import { render as mjRender } from "mjml-react";
 
 export function render(
-  component: ReactElement<any, string | JSXElementConstructor<any>>
+  component: ReactElement<any, string | JSXElementConstructor<any>>,
+  minifyCb?: (html: string) => string
 ) {
-  return mjRender(component, {
+  const { html, errors } = mjRender(component, {
     validationLevel: "soft",
     minify: undefined,
   });
+
+  return {
+    html: minifyCb?.(html) || html,
+    errors,
+  };
 }

--- a/packages/core/src/mjml.ts
+++ b/packages/core/src/mjml.ts
@@ -3,7 +3,9 @@ import { render as mjRender } from "mjml-react";
 
 export function render(
   component: ReactElement<any, string | JSXElementConstructor<any>>,
-  minifyCb?: (html: string) => string
+  options: {
+    processHtml?: (html: string) => string;
+  } = {}
 ) {
   const { html, errors } = mjRender(component, {
     validationLevel: "soft",
@@ -11,7 +13,7 @@ export function render(
   });
 
   return {
-    html: minifyCb?.(html) || html,
+    html: options.processHtml?.(html) || html,
     errors,
   };
 }

--- a/packages/core/src/mjml.ts
+++ b/packages/core/src/mjml.ts
@@ -3,9 +3,9 @@ import { render as mjRender } from "mjml-react";
 
 export function render(
   component: ReactElement<any, string | JSXElementConstructor<any>>,
-  options: {
+  options?: {
     processHtml?: (html: string) => string;
-  } = {}
+  }
 ) {
   const { html, errors } = mjRender(component, {
     validationLevel: "soft",
@@ -13,7 +13,7 @@ export function render(
   });
 
   return {
-    html: options.processHtml?.(html) || html,
+    html: options?.processHtml?.(html) || html,
     errors,
   };
 }

--- a/packages/web/pages/docs/sending-email.mdx
+++ b/packages/web/pages/docs/sending-email.mdx
@@ -33,13 +33,14 @@ const sendMail = buildSendMail({
   defaultFrom: "Steven from Dub <steven@dub.sh>",
   configPath: "./mailing.config.json",
   // optional
-  minifyCb: (html: string) => htmlMinify(html, {
-        caseSensitive: true,
-        collapseWhitespace: true,
-        minifyCSS: true,
-        removeComments: true,
-        removeEmptyAttributes: true,
-      })
+  processHtml: (html: string) =>
+    htmlMinify(html, {
+      caseSensitive: true,
+      collapseWhitespace: true,
+      minifyCSS: true,
+      removeComments: true,
+      removeEmptyAttributes: true,
+    }),
 });
 ```
 

--- a/packages/web/pages/docs/sending-email.mdx
+++ b/packages/web/pages/docs/sending-email.mdx
@@ -32,6 +32,14 @@ const sendMail = buildSendMail({
   }),
   defaultFrom: "Steven from Dub <steven@dub.sh>",
   configPath: "./mailing.config.json",
+  // optional
+  minifyCb: (html: string) => htmlMinify(html, {
+        caseSensitive: true,
+        collapseWhitespace: true,
+        minifyCSS: true,
+        removeComments: true,
+        removeEmptyAttributes: true,
+      })
 });
 ```
 


### PR DESCRIPTION
## Describe your changes
Currently, the `sendMail` api turns off minification by default and does not provide a mechanism by which users can supply their own minification. This pull request seeks to change that by adding an optional callback to the `buildSendMail` option arg, that if present, will be called using html created from the `react-mjml` render method, and returned from the `mailing` render method. 

This approach decouples the minifier dependency from the larger mailing repository which means that users can use any library or implementation they please, as long as the callback accepts a string as an argument and returns a string, reducing the maintenance burden on the mailing support team.

## Issue link
N/A

## Checklist before requesting a review

- [ x ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
