### PR TITLE
Add subject to /api/render response

### DIFF
--- a/packages/cli/src/util/renderTemplate.ts
+++ b/packages/cli/src/util/renderTemplate.ts
@@ -1,18 +1,20 @@
 import React from "react";
 import { render } from "mailing-core";
 import { templates } from "../moduleManifest";
+import { getTemplateModule } from './moduleManifestUtil'
 
 type renderTemplateResult = {
   error?: string;
   mjmlErrors?: MjmlError[];
   html?: string;
+  subject?: string;
 };
 
 const renderTemplate = (
   templateName: string,
   props: { [key: string]: any }
 ): renderTemplateResult => {
-  const Template = templates[templateName as keyof typeof templates];
+  const Template = getTemplateModule(templateName)
   if (!Template) {
     return {
       error: `Template ${templateName} not found in list of templates: ${Object.keys(
@@ -21,7 +23,20 @@ const renderTemplate = (
     };
   }
 
-  return render(React.createElement(Template as any, props));
+  const { html, errors } = render(React.createElement(Template as any, props));
+
+  let subject
+  if (typeof Template.subject === "function") {
+    subject = Template.subject(props);
+  } else if (typeof Template.subject === "string") {
+    subject = Template.subject;
+  }
+
+  return {
+    html,
+    subject,
+    mjmlErrors: errors,
+  }
 };
 
 export default renderTemplate;

--- a/packages/web/pages/docs/rest-api.mdx
+++ b/packages/web/pages/docs/rest-api.mdx
@@ -167,7 +167,7 @@ is included in the request.
 
 | Status | Description | JSON Response Body                                                                                       |
 | ------ | ----------- | -------------------------------------------------------------------------------------------------------- |
-| 200    | Success     | `html: string` – the rendered HTML `mjmlErrors: string[]` – MJML errors thrown during template rendering |
+| 200    | Success     | `html: string` – the rendered HTML `subhect: string` – the rendered subject `mjmlErrors: string[]` – MJML errors thrown during template rendering |
 
 #### Error responses
 


### PR DESCRIPTION
## Describe your changes

This pull request updates the `/api/render` endpoint to return the template's `subject` if it exists. It also fixes an issue where  MJML render errors were not being returned under the `mjmlErrors` property as described in https://www.mailing.run/docs/rest-api#api-render.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
