### PR TITLE
include `from` option when forcing in intercept preview

### DIFF
--- a/packages/cli/src/components/Intercept.tsx
+++ b/packages/cli/src/components/Intercept.tsx
@@ -22,7 +22,7 @@ const Intercept: React.FC<InterceptProps> = ({ data }) => {
 
   const handleForceDeliver = useCallback(async () => {
     if (!data) return;
-    const { to, cc, bcc, html, subject } = data;
+    const { to, cc, bcc, html, subject, from } = data;
 
     const numRecipients =
       recipientCount(to) + recipientCount(cc) + recipientCount(bcc);
@@ -41,6 +41,7 @@ const Intercept: React.FC<InterceptProps> = ({ data }) => {
         bcc,
         html,
         subject,
+        from,
         dangerouslyForceDeliver: true,
       }),
     });


### PR DESCRIPTION
## Describe your changes
in preview mode, when a call to `/api/sendMail` is intercepted and the user clicks 'force send', the `from` option is now passed along

## Issue link
#479 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
