### PR TITLE
Add truncate for names in sidebar pane

### DIFF
--- a/packages/cli/src/components/IndexPane/CompactView.tsx
+++ b/packages/cli/src/components/IndexPane/CompactView.tsx
@@ -85,7 +85,7 @@ const CompactView: React.FC<CompactViewProps> = ({
                 </svg>
               </button>
             )}
-            <div className="truncate">
+            <div aria-selected={i === cursor} className="truncate">
               {route.displayName}
             </div>
           </div>

--- a/packages/cli/src/components/IndexPane/CompactView.tsx
+++ b/packages/cli/src/components/IndexPane/CompactView.tsx
@@ -50,7 +50,7 @@ const CompactView: React.FC<CompactViewProps> = ({
             role="treeitem"
             aria-expanded={!route.collapsed}
             aria-selected={i === cursor}
-            className={cx("mb-1 cursor-pointer hover:underline", {
+            className={cx("mb-1 pr-2 cursor-pointer hover:underline flex items-center", {
               "pl-2": route.level === 0,
               "pl-6": route.level === 1,
               "pl-[70px] pb-1 pt-1": route.level === 2,
@@ -85,7 +85,9 @@ const CompactView: React.FC<CompactViewProps> = ({
                 </svg>
               </button>
             )}
-            {route.displayName}
+            <div className="truncate">
+              {route.displayName}
+            </div>
           </div>
         );
       })}


### PR DESCRIPTION
## Describe your changes
Truncate names that are overflowed

<img width="299" alt="Screenshot 2023-09-30 at 16 56 58" src="https://github.com/sofn-xyz/mailing/assets/5896181/8cf628a9-d3a6-42ea-a591-108d953a58c7">

## Issue link

https://github.com/sofn-xyz/mailing/issues/446

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
