### PR TITLE
Bad conditional when added error message

### DIFF
--- a/packages/cli/src/pages/api/render.ts
+++ b/packages/cli/src/pages/api/render.ts
@@ -38,9 +38,9 @@ export default async function handler(
   } catch {
     return res.status(422).json({
       error:
-        "props could not be parsed from " + req.method === "GET"
+        "props could not be parsed from " + (req.method === "GET"
           ? "querystring"
-          : "request body",
+          : "request body"),
     });
   }
 


### PR DESCRIPTION
## Describe your changes
Currently the error will always be `request body` without the additional text. I believe the intension of the code was to append  `"querystring"` or `"request body"` depending on the method. 

## Issue link
I discovered this issue while trying to debug another issue and did not understand why I was getting a error message about the `body` when I was sending a `GET` request.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
