### PR TITLE
Restore fake timers via afterEach instead of try/finally

### DIFF
--- a/packages/cli/src/util/__test__/renderTemplate.test.ts
+++ b/packages/cli/src/util/__test__/renderTemplate.test.ts
@@ -1,6 +1,10 @@
 import renderTemplate from "../renderTemplate";
 
 describe("renderTemplate", () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it("throws an error if template not found", () => {
     const { error, mjmlErrors, html } = renderTemplate("test", {
       name: "test",
@@ -14,16 +18,12 @@ describe("renderTemplate", () => {
     // Freeze the clock so the footer's "© {year}" copyright renders
     // deterministically — otherwise this snapshot rots every Jan 1.
     jest.useFakeTimers().setSystemTime(new Date("2023-06-15T00:00:00Z"));
-    try {
-      const { error, mjmlErrors, html } = renderTemplate("AccountCreated", {
-        name: "Test User",
-      });
-      expect(mjmlErrors).toEqual([]);
-      expect(error).toBeUndefined();
-      expect(html).not.toBeUndefined();
-      expect(html).toMatchSnapshot();
-    } finally {
-      jest.useRealTimers();
-    }
+    const { error, mjmlErrors, html } = renderTemplate("AccountCreated", {
+      name: "Test User",
+    });
+    expect(mjmlErrors).toEqual([]);
+    expect(error).toBeUndefined();
+    expect(html).not.toBeUndefined();
+    expect(html).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
Follow-up cleanup to #502.

The snapshot time-bomb fix in #502 wrapped the test body in a try/finally to restore real timers. An `afterEach(() => jest.useRealTimers())` hook does the same job — guaranteed restoration on pass or fail — without the noise, so the test body reads straight through.

No behavior change; `yarn jest` passes.