### PR TITLE
e2e: harden index.cy.js tree assertions against label wrappers

### DIFF
--- a/e2e/mailing_tests/cypress/e2e/index.cy.js
+++ b/e2e/mailing_tests/cypress/e2e/index.cy.js
@@ -6,10 +6,12 @@ describe("index page tests", () => {
   it("should redirect index to previewFunction with tree", () => {
     cy.location("pathname").should("eq", "/previews/Welcome/preview");
 
-    cy.contains("preview")
+    // Scope to the treeitem rather than the label text so the assertions stay
+    // valid when the label is wrapped (e.g. in a truncating element).
+    cy.contains('[role="treeitem"]', "preview")
       .should("have.attr", "aria-selected", "true")
       .should("have.attr", "role", "treeitem");
-    cy.contains("Emails")
+    cy.contains('[role="treeitem"]', "Emails")
       .should("have.attr", "aria-expanded", "true")
       .should("have.attr", "aria-selected", "false")
       .should("have.attr", "role", "treeitem");


### PR DESCRIPTION
The `index.cy.js` tree assertions used `cy.contains("preview")` / `cy.contains("Emails")`, which match the label **text** directly. That element was the `role="treeitem"` div only because the label was a direct child. #484 (truncate long names in the sidebar) wraps the label in a `<div class="truncate">`, so `cy.contains` starts matching the wrapper — which lacks `role="treeitem"` and `aria-expanded` — and the assertions fail.

This scopes the assertions to the treeitem via `cy.contains('[role="treeitem"]', ...)`, so they stay valid whether or not the label is wrapped.

Verified locally (running the spec against the built preview app): passes **both** on current main (no wrapper) and with #484's truncate wrapper applied. Unblocks #484's e2e once its branch is updated with main.