### PR TITLE
Fix cypress index test broken by #484's truncate wrapper

### DIFF
--- a/packages/cli/cypress/e2e/index.cy.js
+++ b/packages/cli/cypress/e2e/index.cy.js
@@ -1,5 +1,3 @@
-const { isBindingElement } = require("typescript");
-
 describe("index page tests", () => {
   beforeEach(() => {
     cy.visit("/");
@@ -8,10 +6,12 @@ describe("index page tests", () => {
   it("should redirect index to previewFunction with tree", () => {
     cy.location("pathname").should("eq", "/previews/Welcome/preview");
 
-    cy.contains("preview")
+    // Scope to the treeitem rather than the label text so the assertions stay
+    // valid when the label is wrapped (e.g. in a truncating element).
+    cy.contains('[role="treeitem"]', "preview")
       .should("have.attr", "aria-selected", "true")
       .should("have.attr", "role", "treeitem");
-    cy.contains("Emails")
+    cy.contains('[role="treeitem"]', "Emails")
       .should("have.attr", "aria-expanded", "true")
       .should("have.attr", "aria-selected", "false")
       .should("have.attr", "role", "treeitem");


### PR DESCRIPTION
`packages/cli/cypress/e2e/index.cy.js` (the repo-level cypress spec) had the same brittle `cy.contains("preview")` / `cy.contains("Emails")` assertions that #508 hardened in the e2e copy — but this file was missed. #484's truncate `<div>` wrapper makes `cy.contains` match the wrapper (which lacks `role`/`aria-expanded`), so the **cypress** workflow started failing on main.

Scopes the assertions to `cy.contains('[role="treeitem"]', ...)` (same fix as #508) and drops a stray unused `require("typescript")`. Test-only — no published code changes, so no re-release needed.